### PR TITLE
CLI helper: Create Escrow Account

### DIFF
--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -20,6 +20,7 @@ solana-client = { workspace = true }
 solana-commitment-config = { workspace = true }
 solana-hash = { workspace = true }
 solana-instruction = { workspace = true }
+solana-keypair = { workspace = true }
 solana-logger = { workspace = true }
 solana-presigner = { workspace = true }
 solana-program-pack = { workspace = true }

--- a/clients/cli/src/cli.rs
+++ b/clients/cli/src/cli.rs
@@ -20,6 +20,7 @@ use {
     solana_remote_wallet::remote_wallet::RemoteWalletManager,
     std::rc::Rc,
 };
+use crate::create_escrow_account::{command_create_escrow_account, CreateEscrowAccountArgs};
 
 #[derive(Parser, Debug, Clone)]
 #[clap(
@@ -94,6 +95,8 @@ pub enum Command {
     FindPdas(FindPdasArgs),
     /// Convert wrapped tokens back into their original unwrapped version
     Unwrap(UnwrapArgs),
+    /// Create an account used to escrow unwrapped tokens
+    CreateEscrowAccount(CreateEscrowAccountArgs),
 }
 
 impl Command {
@@ -108,6 +111,7 @@ impl Command {
             Command::Wrap(args) => command_wrap(config, args, matches, wallet_manager).await,
             Command::FindPdas(args) => command_get_pdas(config, args).await,
             Command::Unwrap(args) => command_unwrap(config, args, matches, wallet_manager).await,
+            Command::CreateEscrowAccount(args) => command_create_escrow_account(config, args).await,
         }
     }
 }

--- a/clients/cli/src/cli.rs
+++ b/clients/cli/src/cli.rs
@@ -111,7 +111,9 @@ impl Command {
             Command::Wrap(args) => command_wrap(config, args, matches, wallet_manager).await,
             Command::FindPdas(args) => command_get_pdas(config, args).await,
             Command::Unwrap(args) => command_unwrap(config, args, matches, wallet_manager).await,
-            Command::CreateEscrowAccount(args) => command_create_escrow_account(config, args).await,
+            Command::CreateEscrowAccount(args) => {
+                command_create_escrow_account(config, args, matches, wallet_manager).await
+            }
         }
     }
 }

--- a/clients/cli/src/cli.rs
+++ b/clients/cli/src/cli.rs
@@ -1,6 +1,7 @@
 use {
     crate::{
         config::Config,
+        create_escrow_account::{command_create_escrow_account, CreateEscrowAccountArgs},
         create_mint::{command_create_mint, CreateMintArgs},
         find_pdas::{command_get_pdas, FindPdasArgs},
         output::parse_output_format,
@@ -20,7 +21,6 @@ use {
     solana_remote_wallet::remote_wallet::RemoteWalletManager,
     std::rc::Rc,
 };
-use crate::create_escrow_account::{command_create_escrow_account, CreateEscrowAccountArgs};
 
 #[derive(Parser, Debug, Clone)]
 #[clap(

--- a/clients/cli/src/common.rs
+++ b/clients/cli/src/common.rs
@@ -4,11 +4,14 @@ use {
     solana_clap_v3_utils::keypair::pubkey_from_path,
     solana_client::nonblocking::rpc_client::RpcClient,
     solana_presigner::Presigner,
-    solana_program_pack::Pack,
     solana_pubkey::Pubkey,
     solana_signature::Signature,
     solana_transaction::Transaction,
-    spl_token_2022::{extension::PodStateWithExtensions, pod::PodAccount},
+    spl_token_2022::{
+        extension::{PodStateWithExtensions, StateWithExtensions},
+        pod::PodAccount,
+        state::Mint,
+    },
     std::str::FromStr,
 };
 
@@ -107,7 +110,7 @@ pub async fn assert_mint_account(
     }
 
     // Attempt to deserialize the data as a mint account
-    let _ = Mint::unpack(&account_info.data)
+    let _ = StateWithExtensions::<Mint>::unpack(&account_info.data)
         .map_err(|e| format!("Failed to unpack as spl token mint: {:?}", e))?;
 
     Ok(())

--- a/clients/cli/src/create_escrow_account.rs
+++ b/clients/cli/src/create_escrow_account.rs
@@ -1,10 +1,9 @@
 use {
-    crate::common::get_account_owner, solana_keypair::Keypair,
-    spl_token_2022::instruction::initialize_account,
-};
-use {
     crate::{
-        common::{parse_pubkey, parse_token_program, process_transaction}, /* Keep parse_token_program if we add an override flag later */
+        common::{
+            assert_mint_account, get_account_owner, parse_pubkey, parse_token_program,
+            process_transaction,
+        },
         config::Config,
         output::{format_output, println_display},
         CommandResult,
@@ -12,15 +11,30 @@ use {
     clap::Args,
     serde_derive::{Deserialize, Serialize},
     serde_with::{serde_as, DisplayFromStr},
+    solana_clap_v3_utils::{
+        input_parsers::signer::{SignerSource, SignerSourceParserBuilder},
+        keypair::signer_from_source,
+    },
     solana_cli_output::{display::writeln_name_value, QuietDisplay, VerboseDisplay},
     solana_program_pack::Pack,
     solana_pubkey::Pubkey,
+    solana_remote_wallet::remote_wallet::RemoteWalletManager,
     solana_signature::Signature,
     solana_signer::Signer,
     solana_system_interface::instruction::create_account,
     solana_transaction::Transaction,
+    spl_associated_token_account_client::{
+        address::get_associated_token_address_with_program_id,
+        instruction::{
+            create_associated_token_account, create_associated_token_account_idempotent,
+        },
+    },
+    spl_token_2022::instruction::initialize_account,
     spl_token_wrap::{get_wrapped_mint_address, get_wrapped_mint_authority},
-    std::fmt::{Display, Formatter},
+    std::{
+        fmt::{Display, Formatter},
+        rc::Rc,
+    },
 };
 
 #[derive(Clone, Debug, Args)]
@@ -33,6 +47,16 @@ pub struct CreateEscrowAccountArgs {
     /// The address of the token program for the *wrapped* mint
     #[clap(value_parser = parse_token_program)]
     pub wrapped_token_program: Pubkey,
+
+    /// Keypair source for the escrow account itself.
+    /// If not provided, the Associated Token Account (`ATA`) for the wrapped
+    /// mint authority PDA will be used or created.
+    #[clap(long, value_parser = SignerSourceParserBuilder::default().allow_all().build())]
+    pub escrow_account_signer: Option<SignerSource>,
+
+    /// Do not error if the escrow account already exists and is initialized
+    #[clap(long)]
+    pub idempotent: bool,
 }
 
 #[serde_as]
@@ -46,7 +70,7 @@ pub struct CreateEscrowAccountOutput {
     pub escrow_account_owner: Pubkey, // This is the wrapped_mint_authority PDA
 
     #[serde_as(as = "DisplayFromStr")]
-    pub escrow_token_program_id: Pubkey,
+    pub unwrapped_token_program_id: Pubkey,
 
     #[serde_as(as = "Option<DisplayFromStr>")]
     pub signature: Option<Signature>,
@@ -61,13 +85,13 @@ impl Display for CreateEscrowAccountOutput {
         )?;
         writeln_name_value(
             f,
-            "Escrow Account Owner (PDA):",
+            "Escrow Account Owner (wrapped mint authority):",
             &self.escrow_account_owner.to_string(),
         )?;
         writeln_name_value(
             f,
-            "Escrow Token Program ID:",
-            &self.escrow_token_program_id.to_string(),
+            "Unwrapped Token Program ID:",
+            &self.unwrapped_token_program_id.to_string(),
         )?;
         if let Some(signature) = self.signature {
             writeln_name_value(f, "Signature:", &signature.to_string())?;
@@ -86,13 +110,17 @@ impl VerboseDisplay for CreateEscrowAccountOutput {}
 pub async fn command_create_escrow_account(
     config: &Config,
     args: CreateEscrowAccountArgs,
+    matches: &clap::ArgMatches,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> CommandResult {
     let payer = config.fee_payer()?;
     let rpc_client = config.rpc_client.clone();
 
+    // --- Validate Unwrapped Mint ---
+    assert_mint_account(&rpc_client, &args.unwrapped_mint).await?;
+
     // --- Determine Unwrapped Token Program ---
-    let unwrapped_token_program_id =
-        get_account_owner(&args.unwrapped_mint, rpc_client.clone()).await?;
+    let unwrapped_token_program_id = get_account_owner(&args.unwrapped_mint, &rpc_client).await?;
 
     // --- Derive PDAs ---
     let wrapped_mint_address =
@@ -102,51 +130,119 @@ pub async fn command_create_escrow_account(
     println_display(
         config,
         format!(
-            "Creating escrow account under program {} for unwrapped mint {} owned by PDA {}",
+            "Creating escrow account under program {} for unwrapped mint {} owned by wrapped mint \
+             authority {}",
             unwrapped_token_program_id, args.unwrapped_mint, wrapped_mint_authority
         ),
     );
 
-    // --- Prepare Escrow Creation ---
-    let escrow_keypair = Keypair::new();
-    let escrow_account_address = escrow_keypair.pubkey();
+    let mut instructions = Vec::new();
+    let mut signers = vec![payer.clone()];
+    let escrow_account_address: Pubkey;
 
-    let account_len = spl_token_2022::state::Account::LEN;
-    let rent = rpc_client
-        .get_minimum_balance_for_rent_exemption(account_len)
-        .await?;
-    let create_account_instruction = create_account(
-        &payer.pubkey(),
-        &escrow_account_address,
-        rent,
-        account_len as u64,
-        &unwrapped_token_program_id,
-    );
+    // --- Decide How to Create Escrow Account ---
+    if let Some(signer_source) = &args.escrow_account_signer {
+        // --- Case 1: User Supplied a Signer for the Escrow Account ---
+        let escrow_signer = signer_from_source(
+            matches,
+            signer_source,
+            "escrow_account_signer",
+            wallet_manager,
+        )
+        .map_err(|e| format!("Failed to load escrow account signer: {}", e))?;
+        escrow_account_address = escrow_signer.pubkey();
+        signers.push(std::sync::Arc::from(escrow_signer));
 
-    let initialize_instruction = initialize_account(
-        &unwrapped_token_program_id,
-        &escrow_account_address,
-        &args.unwrapped_mint,
-        &wrapped_mint_authority,
-    )?;
+        // Check whether this account already exists.
+        match rpc_client.get_account(&escrow_account_address).await {
+            // Account exists
+            Ok(_) => {
+                if args.idempotent {
+                    println_display(
+                        config,
+                        format!(
+                            "Escrow account {} already exists, skipping creation",
+                            escrow_account_address
+                        ),
+                    );
+                } else {
+                    return Err(format!(
+                        "Escrow account {} already exists",
+                        escrow_account_address
+                    )
+                    .into());
+                }
+            }
+            // Account does not exist, create it
+            Err(_) => {
+                let account_len = spl_token_2022::state::Account::LEN;
+                let rent_exempt_min = rpc_client
+                    .get_minimum_balance_for_rent_exemption(account_len)
+                    .await?;
 
-    // --- Build and Send Transaction ---
-    let latest_blockhash = rpc_client.get_latest_blockhash().await?;
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_account_instruction, initialize_instruction],
-        Some(&payer.pubkey()),
-        &[&*payer, &escrow_keypair],
-        latest_blockhash,
-    );
+                instructions.push(create_account(
+                    &payer.pubkey(),
+                    &escrow_account_address,
+                    rent_exempt_min,
+                    account_len as u64,
+                    &unwrapped_token_program_id,
+                ));
 
-    let signature = process_transaction(config, transaction).await?;
+                instructions.push(initialize_account(
+                    &unwrapped_token_program_id,
+                    &escrow_account_address,
+                    &args.unwrapped_mint,
+                    &wrapped_mint_authority, // The PDA must be the owner
+                )?);
+            }
+        }
+    } else {
+        // --- Case 2: Default to Associated Token Account (ATA) ---
+        escrow_account_address = get_associated_token_address_with_program_id(
+            &wrapped_mint_authority,
+            &args.unwrapped_mint,
+            &unwrapped_token_program_id,
+        );
+
+        println_display(
+            config,
+            format!("Using ATA {} for escrow account", escrow_account_address),
+        );
+
+        let create_ata_instruction = if args.idempotent {
+            create_associated_token_account_idempotent
+        } else {
+            create_associated_token_account
+        };
+
+        instructions.push(create_ata_instruction(
+            &payer.pubkey(),
+            &wrapped_mint_authority,
+            &args.unwrapped_mint,
+            &unwrapped_token_program_id,
+        ));
+    }
+
+    // --- Build and Send Transaction if Needed ---
+    let signature = if instructions.is_empty() {
+        None
+    } else {
+        let latest_blockhash = rpc_client.get_latest_blockhash().await?;
+        let transaction = Transaction::new_signed_with_payer(
+            &instructions,
+            Some(&payer.pubkey()),
+            &signers,
+            latest_blockhash,
+        );
+        process_transaction(config, transaction).await?
+    };
 
     Ok(format_output(
         config,
         CreateEscrowAccountOutput {
             escrow_account_address,
             escrow_account_owner: wrapped_mint_authority,
-            escrow_token_program_id: unwrapped_token_program_id,
+            unwrapped_token_program_id,
             signature,
         },
     ))

--- a/clients/cli/src/create_escrow_account.rs
+++ b/clients/cli/src/create_escrow_account.rs
@@ -1,0 +1,153 @@
+use {
+    crate::common::get_account_owner, solana_keypair::Keypair,
+    spl_token_2022::instruction::initialize_account,
+};
+use {
+    crate::{
+        common::{parse_pubkey, parse_token_program, process_transaction}, /* Keep parse_token_program if we add an override flag later */
+        config::Config,
+        output::{format_output, println_display},
+        CommandResult,
+    },
+    clap::Args,
+    serde_derive::{Deserialize, Serialize},
+    serde_with::{serde_as, DisplayFromStr},
+    solana_cli_output::{display::writeln_name_value, QuietDisplay, VerboseDisplay},
+    solana_program_pack::Pack,
+    solana_pubkey::Pubkey,
+    solana_signature::Signature,
+    solana_signer::Signer,
+    solana_system_interface::instruction::create_account,
+    solana_transaction::Transaction,
+    spl_token_wrap::{get_wrapped_mint_address, get_wrapped_mint_authority},
+    std::fmt::{Display, Formatter},
+};
+
+#[derive(Clone, Debug, Args)]
+#[clap(about = "Creates an escrow token account for holding unwrapped tokens")]
+pub struct CreateEscrowAccountArgs {
+    /// The address of the mint for the unwrapped tokens the escrow will hold
+    #[clap(value_parser = parse_pubkey)]
+    pub unwrapped_mint: Pubkey,
+
+    /// The address of the token program for the *wrapped* mint
+    #[clap(value_parser = parse_token_program)]
+    pub wrapped_token_program: Pubkey,
+}
+
+#[serde_as]
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateEscrowAccountOutput {
+    #[serde_as(as = "DisplayFromStr")]
+    pub escrow_account_address: Pubkey,
+
+    #[serde_as(as = "DisplayFromStr")]
+    pub escrow_account_owner: Pubkey, // This is the wrapped_mint_authority PDA
+
+    #[serde_as(as = "DisplayFromStr")]
+    pub escrow_token_program_id: Pubkey,
+
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    pub signature: Option<Signature>,
+}
+
+impl Display for CreateEscrowAccountOutput {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        writeln_name_value(
+            f,
+            "Escrow Account Address:",
+            &self.escrow_account_address.to_string(),
+        )?;
+        writeln_name_value(
+            f,
+            "Escrow Account Owner (PDA):",
+            &self.escrow_account_owner.to_string(),
+        )?;
+        writeln_name_value(
+            f,
+            "Escrow Token Program ID:",
+            &self.escrow_token_program_id.to_string(),
+        )?;
+        if let Some(signature) = self.signature {
+            writeln_name_value(f, "Signature:", &signature.to_string())?;
+        }
+        Ok(())
+    }
+}
+
+impl QuietDisplay for CreateEscrowAccountOutput {
+    fn write_str(&self, _: &mut dyn std::fmt::Write) -> std::fmt::Result {
+        Ok(())
+    }
+}
+impl VerboseDisplay for CreateEscrowAccountOutput {}
+
+pub async fn command_create_escrow_account(
+    config: &Config,
+    args: CreateEscrowAccountArgs,
+) -> CommandResult {
+    let payer = config.fee_payer()?;
+    let rpc_client = config.rpc_client.clone();
+
+    // --- Determine Unwrapped Token Program ---
+    let unwrapped_token_program_id =
+        get_account_owner(&args.unwrapped_mint, rpc_client.clone()).await?;
+
+    // --- Derive PDAs ---
+    let wrapped_mint_address =
+        get_wrapped_mint_address(&args.unwrapped_mint, &args.wrapped_token_program);
+    let wrapped_mint_authority = get_wrapped_mint_authority(&wrapped_mint_address);
+
+    println_display(
+        config,
+        format!(
+            "Creating escrow account under program {} for unwrapped mint {} owned by PDA {}",
+            unwrapped_token_program_id, args.unwrapped_mint, wrapped_mint_authority
+        ),
+    );
+
+    // --- Prepare Escrow Creation ---
+    let escrow_keypair = Keypair::new();
+    let escrow_account_address = escrow_keypair.pubkey();
+
+    let account_len = spl_token_2022::state::Account::LEN;
+    let rent = rpc_client
+        .get_minimum_balance_for_rent_exemption(account_len)
+        .await?;
+    let create_account_instruction = create_account(
+        &payer.pubkey(),
+        &escrow_account_address,
+        rent,
+        account_len as u64,
+        &unwrapped_token_program_id,
+    );
+
+    let initialize_instruction = initialize_account(
+        &unwrapped_token_program_id,
+        &escrow_account_address,
+        &args.unwrapped_mint,
+        &wrapped_mint_authority,
+    )?;
+
+    // --- Build and Send Transaction ---
+    let latest_blockhash = rpc_client.get_latest_blockhash().await?;
+    let transaction = Transaction::new_signed_with_payer(
+        &[create_account_instruction, initialize_instruction],
+        Some(&payer.pubkey()),
+        &[&*payer, &escrow_keypair],
+        latest_blockhash,
+    );
+
+    let signature = process_transaction(config, transaction).await?;
+
+    Ok(format_output(
+        config,
+        CreateEscrowAccountOutput {
+            escrow_account_address,
+            escrow_account_owner: wrapped_mint_authority,
+            escrow_token_program_id: unwrapped_token_program_id,
+            signature,
+        },
+    ))
+}

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -1,6 +1,7 @@
 mod cli;
 mod common;
 mod config;
+mod create_escrow_account;
 mod create_mint;
 mod find_pdas;
 mod output;

--- a/clients/cli/tests/helpers.rs
+++ b/clients/cli/tests/helpers.rs
@@ -13,7 +13,8 @@ use {
     solana_test_validator::{TestValidator, TestValidatorGenesis, UpgradeableProgramInfo},
     solana_transaction::Transaction,
     spl_associated_token_account_client::address::get_associated_token_address_with_program_id,
-    spl_token::{self, instruction::initialize_mint, state::Mint as SplTokenMint},
+    spl_token::{self, state::Mint as SplTokenMint},
+    spl_token_2022::instruction::initialize_mint,
     std::{error::Error, path::PathBuf, process::Command, sync::Arc},
     tempfile::NamedTempFile,
 };

--- a/clients/cli/tests/test_create_escrow_account.rs
+++ b/clients/cli/tests/test_create_escrow_account.rs
@@ -2,8 +2,11 @@ use {
     crate::helpers::{create_unwrapped_mint, setup_test_env, TestEnv, TOKEN_WRAP_CLI_BIN},
     serde_json::Value,
     serial_test::serial,
+    solana_keypair::{write_keypair_file, Keypair},
     solana_program_pack::IsInitialized,
     solana_pubkey::Pubkey,
+    solana_signer::Signer,
+    solana_transaction::Transaction,
     spl_token::{self},
     spl_token_2022::{
         extension::PodStateWithExtensions,
@@ -12,6 +15,7 @@ use {
     },
     spl_token_wrap::{get_wrapped_mint_address, get_wrapped_mint_authority},
     std::{process::Command, str::FromStr},
+    tempfile::NamedTempFile,
 };
 
 mod helpers;
@@ -29,7 +33,7 @@ async fn assert_escrow_creation(
     let cli_reported_owner_pda_str = cli_output["escrowAccountOwner"].as_str().unwrap();
     let cli_reported_owner_pda = Pubkey::from_str(cli_reported_owner_pda_str).unwrap();
 
-    let cli_reported_token_program_str = cli_output["escrowTokenProgramId"].as_str().unwrap();
+    let cli_reported_token_program_str = cli_output["unwrappedTokenProgramId"].as_str().unwrap();
     let cli_reported_token_program_id = Pubkey::from_str(cli_reported_token_program_str).unwrap();
 
     let escrow_account = env
@@ -57,7 +61,7 @@ async fn assert_escrow_creation(
 
 #[tokio::test]
 #[serial]
-async fn test_create_escrow_account_for_spl_token_mint() {
+async fn test_create_ata_escrow_account_for_spl_token_mint() {
     let env = setup_test_env().await;
     let unwrapped_token_program_id = spl_token::id();
     let wrapped_token_program_id = spl_token_2022::id();
@@ -97,7 +101,7 @@ async fn test_create_escrow_account_for_spl_token_mint() {
 
 #[tokio::test]
 #[serial]
-async fn test_create_escrow_account_for_token2022_mint() {
+async fn test_create_ata_escrow_account_for_token2022_mint() {
     let env = setup_test_env().await;
     let unwrapped_token_program_id = spl_token_2022::id();
     let wrapped_token_program_id = spl_token::id();
@@ -133,4 +137,229 @@ async fn test_create_escrow_account_for_token2022_mint() {
         &unwrapped_token_program_id,
     )
     .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn test_create_escrow_account_with_signer() {
+    let env = setup_test_env().await;
+    let unwrapped_token_program_id = spl_token::id();
+    let wrapped_token_program_id = spl_token_2022::id();
+
+    let unwrapped_mint = create_unwrapped_mint(&env, &unwrapped_token_program_id).await;
+
+    // Create a keypair for the escrow account
+    let escrow_keypair = Keypair::new();
+    let escrow_keypair_file = NamedTempFile::new().unwrap();
+    write_keypair_file(&escrow_keypair, &escrow_keypair_file).unwrap();
+
+    let mut command = Command::new(TOKEN_WRAP_CLI_BIN);
+    let output = command
+        .args([
+            "create-escrow-account",
+            "-C",
+            &env.config_file_path,
+            &unwrapped_mint.to_string(),
+            &wrapped_token_program_id.to_string(),
+            "--escrow-account-signer",
+            escrow_keypair_file.path().to_str().unwrap(),
+            "--output",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        panic!(
+            "Creation with signer failed with status: {}\nStdout: {}\nStderr: {}",
+            output.status, stdout, stderr
+        );
+    }
+
+    let output_str = String::from_utf8(output.stdout).unwrap();
+    let json_result: Value = serde_json::from_str(&output_str).unwrap();
+
+    let wrapped_mint_address = get_wrapped_mint_address(&unwrapped_mint, &wrapped_token_program_id);
+    let expected_owner_pda = get_wrapped_mint_authority(&wrapped_mint_address);
+
+    assert_escrow_creation(
+        &env,
+        &json_result,
+        &expected_owner_pda,
+        &unwrapped_mint,
+        &unwrapped_token_program_id,
+    )
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn test_create_escrow_account_signer_idempotent() {
+    let env = setup_test_env().await;
+    let unwrapped_token_program_id = spl_token::id();
+    let wrapped_token_program_id = spl_token_2022::id();
+
+    let unwrapped_mint = create_unwrapped_mint(&env, &unwrapped_token_program_id).await;
+
+    let escrow_keypair = Keypair::new();
+    let escrow_keypair_file = NamedTempFile::new().unwrap();
+    write_keypair_file(&escrow_keypair, &escrow_keypair_file).unwrap();
+
+    let args = [
+        "create-escrow-account",
+        "-C",
+        &env.config_file_path,
+        &unwrapped_mint.to_string(),
+        &wrapped_token_program_id.to_string(),
+        "--escrow-account-signer",
+        escrow_keypair_file.path().to_str().unwrap(),
+        "--idempotent",
+    ];
+    let mut command_a = Command::new(TOKEN_WRAP_CLI_BIN);
+    let status_a = command_a.args(args).status().unwrap();
+    assert!(status_a.success());
+
+    // Second time, same arguments w/ idempotent successful
+    let mut command_b = Command::new(TOKEN_WRAP_CLI_BIN);
+    let status_b = command_b.args(args).status().unwrap();
+    assert!(status_b.success());
+
+    // Running without idempotent flag will raise an error on subsequent run
+    let mut command_c = Command::new(TOKEN_WRAP_CLI_BIN);
+    let output = command_c
+        .args([
+            "create-escrow-account",
+            "-C",
+            &env.config_file_path,
+            &unwrapped_mint.to_string(),
+            &wrapped_token_program_id.to_string(),
+            "--escrow-account-signer",
+            escrow_keypair_file.path().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr
+        .contains(format!("Escrow account {} already exists", escrow_keypair.pubkey()).as_str()));
+}
+
+#[tokio::test]
+#[serial]
+async fn test_create_escrow_account_ata_idempotent() {
+    let env = setup_test_env().await;
+    let unwrapped_token_program_id = spl_token::id();
+    let wrapped_token_program_id = spl_token_2022::id();
+
+    let unwrapped_mint = create_unwrapped_mint(&env, &unwrapped_token_program_id).await;
+
+    let args = [
+        "create-escrow-account",
+        "-C",
+        &env.config_file_path,
+        &unwrapped_mint.to_string(),
+        &wrapped_token_program_id.to_string(),
+        "--idempotent",
+    ];
+    let mut command_a = Command::new(TOKEN_WRAP_CLI_BIN);
+    let status_a = command_a.args(args).status().unwrap();
+    assert!(status_a.success());
+
+    // Second time, same arguments w/ idempotent successful
+    let mut command_b = Command::new(TOKEN_WRAP_CLI_BIN);
+    let status_b = command_b.args(args).status().unwrap();
+    assert!(status_b.success());
+
+    // Running without idempotent flag will raise an error on subsequent run
+    let mut command_c = Command::new(TOKEN_WRAP_CLI_BIN);
+    let output_c = command_c
+        .args([
+            "create-escrow-account",
+            "-C",
+            &env.config_file_path,
+            &unwrapped_mint.to_string(),
+            &wrapped_token_program_id.to_string(),
+        ])
+        .output()
+        .unwrap();
+    assert!(!output_c.status.success());
+    let stderr_c = String::from_utf8(output_c.stderr).unwrap();
+    assert!(stderr_c.contains("Provided owner is not allowed"));
+}
+
+#[tokio::test]
+#[serial]
+async fn test_create_escrow_account_with_wrong_mint_owner() {
+    let env = setup_test_env().await;
+
+    let keypair = Keypair::new();
+    let wrong_owner = Pubkey::new_unique();
+    create_account(&env, &keypair, &wrong_owner).await;
+
+    let mut command = Command::new(TOKEN_WRAP_CLI_BIN);
+    let output = command
+        .args([
+            "create-escrow-account",
+            "-C",
+            &env.config_file_path,
+            &keypair.pubkey().to_string(),
+            &spl_token_2022::id().to_string(),
+        ])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("is not owned by a token program"));
+}
+
+#[tokio::test]
+#[serial]
+async fn test_create_escrow_account_with_wrong_account_type() {
+    let env = setup_test_env().await;
+
+    let keypair = Keypair::new();
+
+    // note no data in account
+    create_account(&env, &keypair, &spl_token_2022::id()).await;
+
+    let mut command = Command::new(TOKEN_WRAP_CLI_BIN);
+    let output = command
+        .args([
+            "create-escrow-account",
+            "-C",
+            &env.config_file_path,
+            &keypair.pubkey().to_string(),
+            &spl_token_2022::id().to_string(),
+        ])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("Failed to unpack as spl token mint:"));
+}
+
+async fn create_account(env: &TestEnv, key_pair: &Keypair, owner: &Pubkey) {
+    let tx = Transaction::new_signed_with_payer(
+        &[solana_system_interface::instruction::create_account(
+            &env.payer.pubkey(),
+            &key_pair.pubkey(),
+            env.rpc_client
+                .get_minimum_balance_for_rent_exemption(100)
+                .await
+                .unwrap(),
+            100,
+            owner,
+        )],
+        Some(&env.payer.pubkey()),
+        &[&env.payer, key_pair],
+        env.rpc_client.get_latest_blockhash().await.unwrap(),
+    );
+    env.rpc_client
+        .send_and_confirm_transaction(&tx)
+        .await
+        .unwrap();
 }

--- a/clients/cli/tests/test_create_escrow_account.rs
+++ b/clients/cli/tests/test_create_escrow_account.rs
@@ -1,0 +1,136 @@
+use {
+    crate::helpers::{create_unwrapped_mint, setup_test_env, TestEnv, TOKEN_WRAP_CLI_BIN},
+    serde_json::Value,
+    serial_test::serial,
+    solana_program_pack::IsInitialized,
+    solana_pubkey::Pubkey,
+    spl_token::{self},
+    spl_token_2022::{
+        extension::PodStateWithExtensions,
+        pod::PodAccount,
+        {self},
+    },
+    spl_token_wrap::{get_wrapped_mint_address, get_wrapped_mint_authority},
+    std::{process::Command, str::FromStr},
+};
+
+mod helpers;
+
+async fn assert_escrow_creation(
+    env: &TestEnv,
+    cli_output: &Value,
+    expected_owner_pda: &Pubkey,
+    unwrapped_mint: &Pubkey,
+    expected_token_program_id: &Pubkey,
+) {
+    let escrow_account_address_str = cli_output["escrowAccountAddress"].as_str().unwrap();
+    let escrow_account_address = Pubkey::from_str(escrow_account_address_str).unwrap();
+
+    let cli_reported_owner_pda_str = cli_output["escrowAccountOwner"].as_str().unwrap();
+    let cli_reported_owner_pda = Pubkey::from_str(cli_reported_owner_pda_str).unwrap();
+
+    let cli_reported_token_program_str = cli_output["escrowTokenProgramId"].as_str().unwrap();
+    let cli_reported_token_program_id = Pubkey::from_str(cli_reported_token_program_str).unwrap();
+
+    let escrow_account = env
+        .rpc_client
+        .get_account(&escrow_account_address)
+        .await
+        .unwrap();
+
+    // --- Assertions ---
+
+    // 1. Verify the owner program ID reported by CLI and on-chain matches expected
+    assert_eq!(cli_reported_token_program_id, *expected_token_program_id);
+    assert_eq!(escrow_account.owner, *expected_token_program_id);
+
+    // 2. Verify the PDA owner reported by CLI and expected matches
+    assert_eq!(cli_reported_owner_pda, *expected_owner_pda);
+
+    // 3. Verify the on-chain account state
+    let account_state = PodStateWithExtensions::<PodAccount>::unpack(&escrow_account.data).unwrap();
+    assert!(account_state.base.is_initialized());
+    assert_eq!(account_state.base.mint, *unwrapped_mint);
+    assert_eq!(account_state.base.owner, *expected_owner_pda);
+    assert_eq!(account_state.base.amount, 0.into());
+}
+
+#[tokio::test]
+#[serial]
+async fn test_create_escrow_account_for_spl_token_mint() {
+    let env = setup_test_env().await;
+    let unwrapped_token_program_id = spl_token::id();
+    let wrapped_token_program_id = spl_token_2022::id();
+
+    let unwrapped_mint = create_unwrapped_mint(&env, &unwrapped_token_program_id).await;
+
+    let wrapped_mint_address = get_wrapped_mint_address(&unwrapped_mint, &wrapped_token_program_id);
+    let expected_owner_pda = get_wrapped_mint_authority(&wrapped_mint_address);
+
+    let mut command = Command::new(TOKEN_WRAP_CLI_BIN);
+    let output = command
+        .args([
+            "create-escrow-account",
+            "-C",
+            &env.config_file_path,
+            &unwrapped_mint.to_string(),
+            &wrapped_token_program_id.to_string(),
+            "--output",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let output_str = String::from_utf8(output.stdout).unwrap();
+    let json_result: Value = serde_json::from_str(&output_str).unwrap();
+
+    assert_escrow_creation(
+        &env,
+        &json_result,
+        &expected_owner_pda,
+        &unwrapped_mint,
+        &unwrapped_token_program_id,
+    )
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn test_create_escrow_account_for_token2022_mint() {
+    let env = setup_test_env().await;
+    let unwrapped_token_program_id = spl_token_2022::id();
+    let wrapped_token_program_id = spl_token::id();
+
+    let unwrapped_mint = create_unwrapped_mint(&env, &unwrapped_token_program_id).await;
+
+    let wrapped_mint_address = get_wrapped_mint_address(&unwrapped_mint, &wrapped_token_program_id);
+    let expected_owner_pda = get_wrapped_mint_authority(&wrapped_mint_address);
+
+    let mut command = Command::new(TOKEN_WRAP_CLI_BIN);
+    let output = command
+        .args([
+            "create-escrow-account",
+            "-C",
+            &env.config_file_path,
+            &unwrapped_mint.to_string(),
+            &wrapped_token_program_id.to_string(),
+            "--output",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let output_str = String::from_utf8(output.stdout).unwrap();
+    let json_result: Value = serde_json::from_str(&output_str).unwrap();
+
+    assert_escrow_creation(
+        &env,
+        &json_result,
+        &expected_owner_pda,
+        &unwrapped_mint,
+        &unwrapped_token_program_id,
+    )
+    .await;
+}

--- a/clients/cli/tests/test_create_escrow_account.rs
+++ b/clients/cli/tests/test_create_escrow_account.rs
@@ -286,7 +286,7 @@ async fn test_create_escrow_account_ata_idempotent() {
         .unwrap();
     assert!(!output_c.status.success());
     let stderr_c = String::from_utf8(output_c.stderr).unwrap();
-    assert!(stderr_c.contains("Provided owner is not allowed"));
+    assert!(stderr_c.contains("already exists"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
A CLI utility helper for creating an escrow account for the token-wrap program. This specifically helps consumers generate one with the right mint authority for the wrap instruction.

### Walkthrough for testing locally:

1. Build program and binary
```bash
cargo build-sbf && cargo build
```

2. Start solana test validator
```bash
solana-test-validator \
  --bpf-program TwRapQCDhWkZRrDaHfZGuHxkZ91gHDRkyuzNqeU5MgR target/deploy/spl_token_wrap.so \
  --reset
```

3. Create a new mint
```bash
spl-token create-token
# mint addr -> 7uN7hezPKhsCs59xChKgmZnGGjEfEQwE8sAWVxrUSmHV
```

4. Create Escrow account (first arg mint, second wrapped token program addr)
```bash
cargo run --bin spl-token-wrap create-escrow-account 7uN7hezPKhsCs59xChKgmZnGGjEfEQwE8sAWVxrUSmHV TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb

# Escrow Account Address: 7zRuC2akyz9bAm3xSefwkKxzfqcLD7Ly2dUJxZUoBUb2
# Escrow Account Owner (PDA): CvecTxZ2SdRN4bjNXkQL4BGHnJpvwaZneKQnvsWUAfc2
# Escrow Token Program ID: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
# Signature: 2GjCm5snYsVEjQB687qPB95hMZRWnPaymfWfqdUGDTLYNF35Svd6Uw9UGXnnJfJnBG6qzWZiyNvp1AH2uA4gxsSi

```

