### PR TITLE
Update stale review policy

### DIFF
--- a/.github/workflows/dismiss-stale-pr-reviews.yml
+++ b/.github/workflows/dismiss-stale-pr-reviews.yml
@@ -17,6 +17,12 @@ jobs:
   dismiss_stale_approvals:
     runs-on: ubuntu-latest
     steps:
+      - name: Dump GitHub context
+        run: |
+          echo "Author Association: ${{ github.event.pull_request.author_association }}"
+          echo "Full Event Payload:"
+          echo "${{ toJSON(github.event) }}"
+
       - name: Dismiss Stale PR Reviews
         if: ${{ !contains('OWNER,MEMBER,COLLABORATOR', github.event.pull_request.author_association) }}
         uses: withgraphite/dismiss-stale-approvals@main

--- a/.github/workflows/dismiss-stale-pr-reviews.yml
+++ b/.github/workflows/dismiss-stale-pr-reviews.yml
@@ -1,0 +1,24 @@
+name: Dismiss Stale PR Reviews
+
+on:
+  pull_request:
+    types: [
+      opened,
+      synchronize,
+      reopened,
+    ]
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+
+jobs:
+  dismiss_stale_approvals:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dismiss Stale PR Reviews
+        if: ${{ !contains('OWNER,MEMBER,COLLABORATOR', github.event.pull_request.author_association) }}
+        uses: withgraphite/dismiss-stale-approvals@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ node_modules
 test-ledger
 dist
 .idea
+
+test

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,3 @@ node_modules
 test-ledger
 dist
 .idea
-
-test


### PR DESCRIPTION
Taken from https://github.com/anza-xyz/kit/pull/338/files

Currently, when approving a pull request any additional commit or rebase dismisses those reviews. This PR adds a custom workflow to allow post-approval commits without dismissing the status if the contributor is a collaborator on the repo.

The reasoning reflects the same as the PR above. 

Thanks @mcintyre94 for the tip!