### PR TITLE
Validate mint owner

### DIFF
--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -57,6 +57,13 @@ pub fn process_create_mint(
         Err(TokenWrapError::BackpointerMismatch)?
     }
 
+    // The *unwrapped mint* must itself be a real SPL‑Token mint
+    if unwrapped_mint_account.owner != &spl_token::id()
+        && unwrapped_mint_account.owner != &spl_token_2022::id()
+    {
+        Err(ProgramError::InvalidAccountOwner)?
+    }
+
     // Idempotency checks
 
     if wrapped_mint_account.data_len() > 0 || wrapped_backpointer_account.data_len() > 0 {

--- a/program/tests/helpers/create_mint_builder.rs
+++ b/program/tests/helpers/create_mint_builder.rs
@@ -128,6 +128,11 @@ impl<'a> CreateMintBuilder<'a> {
         self
     }
 
+    pub fn unwrapped_mint_account(mut self, account: Account) -> Self {
+        self.unwrapped_mint_account = Some(account);
+        self
+    }
+
     pub fn check(mut self, check: Check<'a>) -> Self {
         self.checks.push(check);
         self

--- a/program/tests/test_create_mint.rs
+++ b/program/tests/test_create_mint.rs
@@ -167,6 +167,22 @@ fn test_improperly_derived_addresses_fail() {
 }
 
 #[test]
+fn test_invalid_unwrapped_mint_owner() {
+    // Create fake unwrapped‑mint account owned by an arbitrary program.
+    let bogus_mint = Account {
+        lamports: 100_000_000,
+        owner: Pubkey::new_unique(), // ← not spl‑token or spl‑token‑2022
+        data: vec![0; spl_token::state::Mint::LEN],
+        ..Account::default()
+    };
+
+    CreateMintBuilder::default()
+        .unwrapped_mint_account(bogus_mint)
+        .check(Check::err(ProgramError::InvalidAccountOwner))
+        .execute();
+}
+
+#[test]
 fn test_successful_spl_token_to_spl_token_2022() {
     let result = CreateMintBuilder::default()
         .unwrapped_token_program(TokenProgram::SplToken)


### PR DESCRIPTION
Audit remediation to validate unwrapped mint has the expected owner. Ultimately, would fail with a `Wrap` instruction, but best to catch it prior to mint creation. 