### PR TITLE
Transfer fee ext support

### DIFF
--- a/program/tests/helpers/common.rs
+++ b/program/tests/helpers/common.rs
@@ -296,9 +296,6 @@ pub fn transfer_fee_mint() -> KeyedAccount {
     let mut mint = PodStateWithExtensionsMut::<PodMint>::unpack_uninitialized(&mut data).unwrap();
 
     let extension = mint.init_extension::<TransferFeeConfig>(true).unwrap();
-
-    extension.transfer_fee_config_authority = Default::default();
-    extension.withdraw_withheld_authority = Default::default();
     extension.withheld_amount = 0.into();
     extension.older_transfer_fee = TransferFee {
         epoch: 0.into(),

--- a/program/tests/helpers/common.rs
+++ b/program/tests/helpers/common.rs
@@ -17,12 +17,12 @@ use {
     spl_token_2022::{
         extension::{
             mint_close_authority::MintCloseAuthority,
-            transfer_fee::TransferFeeConfig,
+            transfer_fee::{TransferFee, TransferFeeAmount, TransferFeeConfig},
             transfer_hook::{TransferHook, TransferHookAccount},
             BaseStateWithExtensionsMut, ExtensionType, PodStateWithExtensionsMut,
             StateWithExtensionsMut,
         },
-        pod::{PodCOption, PodMint},
+        pod::{PodAccount, PodCOption, PodMint},
         state::{AccountState, Mint},
     },
     spl_transfer_hook_interface::{
@@ -286,4 +286,77 @@ pub fn setup_native_token(balance: u64, owner: &TransferAuthority) -> (KeyedAcco
         ..Default::default()
     };
     (native_mint, native_token_account)
+}
+
+pub fn transfer_fee_mint() -> KeyedAccount {
+    let mint_len =
+        ExtensionType::try_calculate_account_len::<Mint>(&[ExtensionType::TransferFeeConfig])
+            .unwrap();
+    let mut data = vec![0u8; mint_len];
+    let mut mint = PodStateWithExtensionsMut::<PodMint>::unpack_uninitialized(&mut data).unwrap();
+
+    let extension = mint.init_extension::<TransferFeeConfig>(true).unwrap();
+
+    extension.transfer_fee_config_authority = Default::default();
+    extension.withdraw_withheld_authority = Default::default();
+    extension.withheld_amount = 0.into();
+    extension.older_transfer_fee = TransferFee {
+        epoch: 0.into(),
+        maximum_fee: 50_000.into(),
+        transfer_fee_basis_points: 100.into(), // 1%
+    };
+    extension.newer_transfer_fee = extension.older_transfer_fee;
+
+    mint.base.mint_authority = PodCOption::some(Pubkey::new_unique());
+    mint.base.freeze_authority = PodCOption::some(FREEZE_AUTHORITY);
+    mint.base.supply = MINT_SUPPLY.into();
+    mint.base.decimals = MINT_DECIMALS;
+    mint.base.is_initialized = PodBool::from_bool(true);
+
+    mint.init_account_type().unwrap();
+
+    KeyedAccount {
+        key: Pubkey::new_unique(),
+        account: Account {
+            lamports: Rent::default().minimum_balance(mint_len),
+            data,
+            owner: spl_token_2022::id(),
+            ..Default::default()
+        },
+    }
+}
+
+pub fn setup_transfer_fee_account(owner: &Pubkey, mint: &Pubkey, initial_amount: u64) -> Account {
+    let account_size =
+        ExtensionType::try_calculate_account_len::<PodAccount>(&[ExtensionType::TransferFeeAmount])
+            .unwrap();
+
+    let mut account = Account {
+        lamports: Rent::default().minimum_balance(account_size),
+        owner: spl_token_2022::id(),
+        data: vec![0; account_size],
+        ..Default::default()
+    };
+
+    let pod_account_data = PodAccount {
+        mint: *mint,
+        owner: *owner,
+        amount: initial_amount.into(),
+        delegate: PodCOption::none(),
+        state: AccountState::Initialized.into(),
+        is_native: PodCOption::none(),
+        delegated_amount: 0.into(),
+        close_authority: PodCOption::none(),
+    };
+
+    let mut state =
+        PodStateWithExtensionsMut::<PodAccount>::unpack_uninitialized(&mut account.data).unwrap();
+    *state.base = pod_account_data;
+
+    let fee_extension = state.init_extension::<TransferFeeAmount>(true).unwrap();
+    fee_extension.withheld_amount = 0.into();
+
+    state.init_account_type().unwrap();
+
+    account
 }

--- a/program/tests/helpers/unwrap_builder.rs
+++ b/program/tests/helpers/unwrap_builder.rs
@@ -198,7 +198,7 @@ impl<'a> UnwrapBuilder<'a> {
         if let TokenProgram::SplToken2022 = token_program {
             state.init_extension::<TransferFeeAmount>(true).unwrap();
             let fee_extension = state.get_extension_mut::<TransferFeeAmount>().unwrap();
-            fee_extension.withheld_amount = 12.into();
+            fee_extension.withheld_amount = 0.into();
         }
 
         KeyedAccount {

--- a/program/tests/helpers/wrap_builder.rs
+++ b/program/tests/helpers/wrap_builder.rs
@@ -204,7 +204,7 @@ impl<'a> WrapBuilder<'a> {
         if let TokenProgram::SplToken2022 = token_program {
             state.init_extension::<TransferFeeAmount>(true).unwrap();
             let fee_extension = state.get_extension_mut::<TransferFeeAmount>().unwrap();
-            fee_extension.withheld_amount = 12.into();
+            fee_extension.withheld_amount = 0.into();
         }
 
         KeyedAccount {


### PR DESCRIPTION
This PR adds support for the token-2022 transfer fee extension. Upon the wrap instruction, a fee is calculated and a "net amount" is now used so the wrapped token minting accounting is consistent with what is transferred in. No changes needed to the unwrap command.

Note: wrapping a mint with a transfer fee does not copy over to the newly created wrapped mint. 


