### PR TITLE
Token Wrap Tests

### DIFF
--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -195,13 +195,12 @@ pub fn process_wrap(accounts: &[AccountInfo], amount: u64) -> ProgramResult {
         Err(TokenWrapError::MintAuthorityMismatch)?
     }
 
-    {
-        let escrow_data = unwrapped_escrow.try_borrow_data()?;
-        let escrow_account = PodStateWithExtensions::<PodAccount>::unpack(&escrow_data)?;
-        if escrow_account.base.owner != expected_authority {
-            Err(TokenWrapError::EscrowOwnerMismatch)?
-        }
+    let escrow_data = unwrapped_escrow.try_borrow_data()?;
+    let escrow_account = PodStateWithExtensions::<PodAccount>::unpack(&escrow_data)?;
+    if escrow_account.base.owner != expected_authority {
+        Err(TokenWrapError::EscrowOwnerMismatch)?
     }
+    drop(escrow_data);
 
     // Transfer unwrapped tokens from user to escrow
 
@@ -238,9 +237,7 @@ pub fn process_wrap(accounts: &[AccountInfo], amount: u64) -> ProgramResult {
             wrapped_mint_authority.clone(),
         ],
         &[&signer_seeds],
-    )?;
-
-    Ok(())
+    )
 }
 
 /// Processes [`Unwrap`](enum.TokenWrapInstruction.html) instruction.
@@ -311,9 +308,7 @@ pub fn process_unwrap(accounts: &[AccountInfo], amount: u64) -> ProgramResult {
         amount,
         unwrapped_mint_state.base.decimals,
         &[&signer_seeds],
-    )?;
-
-    Ok(())
+    )
 }
 
 /// Instruction processor

--- a/program/tests/helpers/common.rs
+++ b/program/tests/helpers/common.rs
@@ -43,7 +43,7 @@ pub fn logger(contents: &str, overwrite: bool) -> io::Result<()> {
     if overwrite {
         options.truncate(true); // overwrite (clear contents)
     } else {
-        options.append(true);   // add to existing file
+        options.append(true); // add to existing file
     }
 
     let mut file = options.open(FILE_PATH)?;
@@ -101,11 +101,7 @@ fn _token_2022_with_extension_data(supply: u64) -> Vec<u8> {
 }
 
 // spl_token and spl_token_2022 are the same account structure except for owner
-pub fn setup_mint(
-    token_program: TokenProgram,
-    rent: &Rent,
-    mint_authority: Pubkey,
-) -> Account {
+pub fn setup_mint(token_program: TokenProgram, rent: &Rent, mint_authority: Pubkey) -> Account {
     let state = spl_token::state::Mint {
         decimals: MINT_DECIMALS,
         is_initialized: true,
@@ -115,7 +111,7 @@ pub fn setup_mint(
     };
     let mut data = match token_program.clone() {
         TokenProgram::SplToken => vec![0u8; spl_token::state::Mint::LEN],
-        TokenProgram::SplToken2022 { extensions} => {
+        TokenProgram::SplToken2022 { extensions } => {
             token_2022_with_extension_data_generic(MINT_SUPPLY, extensions)
         }
     };
@@ -333,7 +329,7 @@ fn token_2022_with_extension_data_generic(supply: u64, extensions: Vec<Extension
     extensions.iter().for_each(|ext| match ext {
         ExtensionType::Uninitialized => _uninitialized(&mut state),
         ExtensionType::TransferFeeConfig => transfer_fee_config(&mut state),
-        ExtensionType::TransferFeeAmount => _transfer_fee_amount(&mut state),
+        ExtensionType::TransferFeeAmount => transfer_fee_amount(&mut state),
         ExtensionType::MintCloseAuthority => mint_close_authority(&mut state),
         ExtensionType::ConfidentialTransferMint => _confidential_transfer_mint(&mut state),
         ExtensionType::ConfidentialTransferAccount => _confidential_transfer_account(&mut state),
@@ -385,9 +381,11 @@ fn transfer_fee_config(state: &mut PodStateWithExtensionsMut<'_, PodMint>) {
     transfer_fee_ext.withheld_amount = PodU64::from(0);
 }
 
-fn _transfer_fee_amount(state: &mut PodStateWithExtensionsMut<'_, PodMint>) {
-    let _ = state;
-    todo!();
+fn transfer_fee_amount(state: &mut PodStateWithExtensionsMut<'_, PodMint>) {
+    let _ = logger(
+        &format!("transfer_fee_amount reached by {:?}\n", state),
+        false,
+    );
 }
 
 /// Initialize MintCloseAuthority extension

--- a/program/tests/helpers/common.rs
+++ b/program/tests/helpers/common.rs
@@ -37,11 +37,16 @@ pub const FILE_PATH: &'static str = "log_file.txt";
 
 /// A utility for logging to a file
 pub fn logger(contents: &str, overwrite: bool) -> io::Result<()> {
-    let mut file = OpenOptions::new()
-        .create(true) // create the file if it doesn't exist
-        .append(overwrite) // append or overwrite
-        .open(FILE_PATH)?;
+    let mut options = OpenOptions::new();
+    options.create(true).write(true);
 
+    if overwrite {
+        options.truncate(true); // overwrite (clear contents)
+    } else {
+        options.append(true);   // add to existing file
+    }
+
+    let mut file = options.open(FILE_PATH)?;
     file.write_all(contents.as_bytes())?;
     Ok(())
 }

--- a/program/tests/helpers/common.rs
+++ b/program/tests/helpers/common.rs
@@ -31,6 +31,20 @@ use {
     std::convert::TryFrom,
 };
 
+use std::fs::OpenOptions;
+use std::io::{self, Write};
+pub const FILE_PATH: &'static str = "log_file.txt";
+
+/// A utility for logging to a file
+pub fn logger(contents: &str, overwrite: bool) -> io::Result<()> {
+    let mut file = OpenOptions::new()
+        .create(true) // create the file if it doesn't exist
+        .append(overwrite) // append or overwrite
+        .open(FILE_PATH)?;
+
+    file.write_all(contents.as_bytes())?;
+    Ok(())
+}
 pub fn init_mollusk() -> Mollusk {
     let mut mollusk = Mollusk::new(&spl_token_wrap::id(), "spl_token_wrap");
     mollusk_svm_programs_token::token::add_program(&mut mollusk);

--- a/program/tests/helpers/create_mint_builder.rs
+++ b/program/tests/helpers/create_mint_builder.rs
@@ -31,9 +31,7 @@ impl KeyedAccount {
 #[derive(Debug, Clone)]
 pub enum TokenProgram {
     SplToken,
-    SplToken2022 {
-        extensions: Vec<ExtensionType>
-    },
+    SplToken2022 { extensions: Vec<ExtensionType> },
 }
 
 impl TokenProgram {
@@ -47,7 +45,9 @@ impl TokenProgram {
     pub fn keyed_account(&self) -> (Pubkey, Account) {
         match self {
             TokenProgram::SplToken => mollusk_svm_programs_token::token::keyed_account(),
-            TokenProgram::SplToken2022 { extensions: _} => mollusk_svm_programs_token::token2022::keyed_account(),
+            TokenProgram::SplToken2022 { extensions: _ } => {
+                mollusk_svm_programs_token::token2022::keyed_account()
+            }
         }
     }
 
@@ -86,7 +86,9 @@ impl Default for CreateMintBuilder<'_> {
         ];
         Self {
             mollusk: init_mollusk(),
-            wrapped_token_program: TokenProgram::SplToken2022 { extensions: EXTENSIONS.into() },
+            wrapped_token_program: TokenProgram::SplToken2022 {
+                extensions: EXTENSIONS.into(),
+            },
             wrapped_token_program_addr: None,
             unwrapped_mint_addr: None,
             unwrapped_mint_account: None,
@@ -194,7 +196,9 @@ impl<'a> CreateMintBuilder<'a> {
 
         let mut keyed_token_program = match self.wrapped_token_program {
             TokenProgram::SplToken => mollusk_svm_programs_token::token::keyed_account(),
-            TokenProgram::SplToken2022 { extensions: _ } => mollusk_svm_programs_token::token2022::keyed_account(),
+            TokenProgram::SplToken2022 { extensions: _ } => {
+                mollusk_svm_programs_token::token2022::keyed_account()
+            }
         };
         keyed_token_program.0 = wrapped_token_program_id;
 

--- a/program/tests/helpers/unwrap_builder.rs
+++ b/program/tests/helpers/unwrap_builder.rs
@@ -10,7 +10,8 @@ use {
     solana_pubkey::Pubkey,
     spl_token_2022::{
         extension::{
-            transfer_fee::TransferFeeAmount, BaseStateWithExtensionsMut, ExtensionType, PodStateWithExtensionsMut
+            transfer_fee::TransferFeeAmount, BaseStateWithExtensionsMut, ExtensionType,
+            PodStateWithExtensionsMut,
         },
         pod::{PodAccount, PodCOption},
     },
@@ -195,7 +196,7 @@ impl<'a> UnwrapBuilder<'a> {
         *state.base = account_data;
         state.init_account_type().unwrap();
 
-        if let TokenProgram::SplToken2022 { extensions} = token_program {
+        if let TokenProgram::SplToken2022 { extensions } = token_program {
             if extensions.contains(&ExtensionType::TransferFeeAmount) {
                 state.init_extension::<TransferFeeAmount>(true).unwrap();
                 let fee_extension = state.get_extension_mut::<TransferFeeAmount>().unwrap();
@@ -214,7 +215,8 @@ impl<'a> UnwrapBuilder<'a> {
         let transfer_authority = self.transfer_authority.clone().unwrap_or_default();
 
         let unwrapped_token_program = self
-            .unwrapped_token_program.clone()
+            .unwrapped_token_program
+            .clone()
             .unwrap_or(TokenProgram::SplToken);
 
         let unwrapped_mint = self.unwrapped_mint.clone().unwrap_or(KeyedAccount {
@@ -227,13 +229,13 @@ impl<'a> UnwrapBuilder<'a> {
         });
 
         let wrapped_token_program = self
-            .wrapped_token_program.clone()
+            .wrapped_token_program
+            .clone()
             .unwrap_or(TokenProgram::default_2022());
 
-        let wrapped_mint = self
-            .wrapped_mint
-            .clone()
-            .unwrap_or_else(|| self.get_wrapped_mint(wrapped_token_program.clone(), unwrapped_mint.key));
+        let wrapped_mint = self.wrapped_mint.clone().unwrap_or_else(|| {
+            self.get_wrapped_mint(wrapped_token_program.clone(), unwrapped_mint.key)
+        });
 
         let wrapped_mint_authority = self
             .wrapped_mint_authority

--- a/program/tests/helpers/wrap_builder.rs
+++ b/program/tests/helpers/wrap_builder.rs
@@ -199,9 +199,10 @@ impl<'a> WrapBuilder<'a> {
         *state.base = recipient_account_data;
         state.init_account_type().unwrap();
 
-        // For SPL Token 2022, initialize the TransferFeeAmount extension
-        if let TokenProgram::SplToken2022 { extensions} = token_program {
+        // For SPL Token 2022
+        if let TokenProgram::SplToken2022 { extensions } = token_program {
             if extensions.contains(&ExtensionType::TransferFeeAmount) {
+                // Initialize the TransferFeeAmount extension
                 state.init_extension::<TransferFeeAmount>(true).unwrap();
                 let fee_extension = state.get_extension_mut::<TransferFeeAmount>().unwrap();
                 fee_extension.withheld_amount = 12.into();
@@ -219,7 +220,8 @@ impl<'a> WrapBuilder<'a> {
         let unwrapped_token_account_authority = self.transfer_authority.clone().unwrap_or_default();
 
         let unwrapped_token_program = self
-            .unwrapped_token_program.clone()
+            .unwrapped_token_program
+            .clone()
             .unwrap_or(TokenProgram::SplToken);
 
         let unwrapped_mint = self.unwrapped_mint.clone().unwrap_or(KeyedAccount {

--- a/program/tests/test_create_mint.rs
+++ b/program/tests/test_create_mint.rs
@@ -170,7 +170,7 @@ fn test_improperly_derived_addresses_fail() {
 fn test_successful_spl_token_to_spl_token_2022() {
     let result = CreateMintBuilder::default()
         .unwrapped_token_program(TokenProgram::SplToken)
-        .wrapped_token_program(TokenProgram::SplToken2022)
+        .wrapped_token_program(TokenProgram::default_2022())
         .execute();
 
     // Assert state of resulting wrapped mint account
@@ -210,7 +210,7 @@ fn test_successful_spl_token_2022_to_spl_token() {
 
     let result = CreateMintBuilder::default()
         .unwrapped_mint_addr(unwrapped_mint_address)
-        .unwrapped_token_program(TokenProgram::SplToken2022)
+        .unwrapped_token_program(TokenProgram::default_2022())
         .wrapped_mint_addr(wrapped_mint_address)
         .wrapped_token_program(TokenProgram::SplToken)
         .execute();

--- a/program/tests/test_unwrap.rs
+++ b/program/tests/test_unwrap.rs
@@ -124,7 +124,9 @@ fn test_successful_spl_token_2022_to_spl_token_unwrap() {
     let wrap_result = UnwrapBuilder::default()
         .wrapped_token_starting_amount(source_starting_amount)
         .unwrapped_token_program(TokenProgram::SplToken)
-        .wrapped_token_program(TokenProgram::SplToken2022 { extensions: vec![ExtensionType::MintCloseAuthority, ExtensionType::TransferFeeConfig] })
+        .wrapped_token_program(TokenProgram::SplToken2022 {
+            extensions: vec![ExtensionType::TransferFeeAmount],
+        })
         .escrow_starting_amount(escrow_starting_amount)
         .recipient_starting_amount(recipient_starting_amount)
         .unwrap_amount(unwrap_amount)
@@ -148,7 +150,9 @@ fn test_successful_spl_token_to_spl_token_2022_unwrap() {
     let unwrap_amount = 40_000;
 
     let wrap_result = UnwrapBuilder::default()
-        .unwrapped_token_program(TokenProgram::SplToken2022 { extensions: vec![ExtensionType::MintCloseAuthority, ExtensionType::TransferFeeConfig] })
+        .unwrapped_token_program(TokenProgram::SplToken2022 {
+            extensions: vec![ExtensionType::TransferFeeAmount],
+        })
         .wrapped_token_program(TokenProgram::SplToken)
         .escrow_starting_amount(escrow_starting_amount)
         .wrapped_token_starting_amount(source_starting_amount)
@@ -174,8 +178,12 @@ fn test_successful_token_2022_to_token_2022_unwrap() {
     let unwrap_amount = 100_000;
 
     let wrap_result = UnwrapBuilder::default()
-        .unwrapped_token_program(TokenProgram::SplToken2022 { extensions: vec![ExtensionType::MintCloseAuthority, ExtensionType::TransferFeeConfig] })
-        .wrapped_token_program(TokenProgram::SplToken2022 { extensions: vec![ExtensionType::MintCloseAuthority, ExtensionType::TransferFeeConfig] })
+        .unwrapped_token_program(TokenProgram::SplToken2022 {
+            extensions: vec![ExtensionType::TransferFeeAmount],
+        })
+        .wrapped_token_program(TokenProgram::SplToken2022 {
+            extensions: vec![ExtensionType::TransferFeeAmount],
+        })
         .escrow_starting_amount(escrow_starting_amount)
         .wrapped_token_starting_amount(source_starting_amount)
         .recipient_starting_amount(recipient_starting_amount)
@@ -203,7 +211,9 @@ fn test_unwrap_with_spl_token_multisig() {
 
     let wrap_result = UnwrapBuilder::default()
         .transfer_authority(multisig)
-        .unwrapped_token_program(TokenProgram::SplToken2022 { extensions: vec![ExtensionType::MintCloseAuthority, ExtensionType::TransferFeeConfig] })
+        .unwrapped_token_program(TokenProgram::SplToken2022 {
+            extensions: vec![ExtensionType::TransferFeeAmount],
+        })
         .wrapped_token_program(TokenProgram::SplToken)
         .escrow_starting_amount(escrow_starting_amount)
         .wrapped_token_starting_amount(source_starting_amount)
@@ -233,7 +243,9 @@ fn test_unwrap_with_spl_token_2022_multisig() {
     let wrap_result = UnwrapBuilder::default()
         .transfer_authority(multisig)
         .unwrapped_token_program(TokenProgram::SplToken)
-        .wrapped_token_program(TokenProgram::SplToken2022 { extensions: vec![ExtensionType::MintCloseAuthority, ExtensionType::TransferFeeConfig] })
+        .wrapped_token_program(TokenProgram::SplToken2022 {
+            extensions: vec![ExtensionType::TransferFeeAmount],
+        })
         .escrow_starting_amount(escrow_starting_amount)
         .wrapped_token_starting_amount(source_starting_amount)
         .recipient_starting_amount(recipient_starting_amount)
@@ -288,8 +300,12 @@ fn test_unwrap_with_transfer_hook() {
 
     // Execute the unwrap instruction using our UnwrapBuilder.
     let unwrap_result = UnwrapBuilder::default()
-        .unwrapped_token_program(TokenProgram::SplToken2022 { extensions: vec![ExtensionType::MintCloseAuthority, ExtensionType::TransferFeeConfig] })
-        .wrapped_token_program(TokenProgram::SplToken2022 { extensions: vec![ExtensionType::MintCloseAuthority, ExtensionType::TransferFeeConfig] })
+        .unwrapped_token_program(TokenProgram::SplToken2022 {
+            extensions: vec![ExtensionType::TransferFeeAmount],
+        })
+        .wrapped_token_program(TokenProgram::SplToken2022 {
+            extensions: vec![ExtensionType::TransferFeeAmount],
+        })
         .wrapped_token_starting_amount(source_starting_amount)
         .recipient_starting_amount(recipient_starting_amount)
         .recipient_token_account(recipient_token_account)
@@ -343,7 +359,9 @@ fn test_successfully_unwraps_to_native_mint() {
     );
 
     let wrap_result = UnwrapBuilder::default()
-        .unwrapped_token_program(TokenProgram::SplToken2022 { extensions: EXTENSIONS.into() })
+        .unwrapped_token_program(TokenProgram::SplToken2022 {
+            extensions: EXTENSIONS.into(),
+        })
         .unwrapped_mint(native_mint)
         .transfer_authority(transfer_authority)
         .recipient_token_account(native_token_account)

--- a/program/tests/test_wrap.rs
+++ b/program/tests/test_wrap.rs
@@ -131,7 +131,9 @@ fn test_successful_spl_token_wrap() {
 
     let wrap_result = WrapBuilder::default()
         .unwrapped_token_program(TokenProgram::SplToken)
-        .wrapped_token_program(TokenProgram::SplToken2022 { extensions: vec![ExtensionType::MintCloseAuthority, ExtensionType::TransferFeeConfig] })
+        .wrapped_token_program(TokenProgram::SplToken2022 {
+            extensions: vec![ExtensionType::TransferFeeAmount],
+        })
         .recipient_starting_amount(starting_amount)
         .wrap_amount(wrap_amount)
         .execute();
@@ -161,7 +163,9 @@ fn test_successful_spl_token_2022_to_token_2022() {
 
     let wrap_result = WrapBuilder::default()
         .unwrapped_token_program(TokenProgram::default_2022())
-        .wrapped_token_program(TokenProgram::SplToken2022 { extensions: vec![ExtensionType::MintCloseAuthority, ExtensionType::TransferFeeConfig] })
+        .wrapped_token_program(TokenProgram::SplToken2022 {
+            extensions: vec![ExtensionType::TransferFeeAmount],
+        })
         .recipient_starting_amount(starting_amount)
         .wrap_amount(wrap_amount)
         .execute();
@@ -236,7 +240,9 @@ fn test_wrap_with_transfer_hook() {
 
     let wrap_result = WrapBuilder::default()
         .unwrapped_token_program(TokenProgram::default_2022())
-        .wrapped_token_program(TokenProgram::SplToken2022 { extensions: vec![ExtensionType::MintCloseAuthority, ExtensionType::TransferFeeConfig] })
+        .wrapped_token_program(TokenProgram::SplToken2022 {
+            extensions: vec![ExtensionType::TransferFeeAmount],
+        })
         .recipient_starting_amount(starting_amount)
         .wrap_amount(wrap_amount)
         .unwrapped_mint(unwrapped_mint)


### PR DESCRIPTION
As part of the audit of the Token Wrap. Some editing to the test harnesses was done to try and make the tests modular for Token2022 Extensions and other functionality. These edits were done on a prior commit of the audit and may be out of date, and were incomplete work at the finalisation of the audit. There may be some value still to be gained, so please feel free to read and use something if it is helpful or close the PR otherwise!