### PR TITLE
Grant dependabot stale approvals

### DIFF
--- a/.github/workflows/dismiss-stale-pr-reviews.yml
+++ b/.github/workflows/dismiss-stale-pr-reviews.yml
@@ -15,10 +15,13 @@ permissions:
 
 jobs:
   dismiss_stale_approvals:
+    # Only run when:
+    # 1) the PR author isn’t dependabot[bot]
+    # 2) the author_association isn't owner/member/collaborator
+    if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' && !contains('OWNER,MEMBER,COLLABORATOR', github.event.pull_request.author_association) }}
     runs-on: ubuntu-latest
     steps:
       - name: Dismiss Stale PR Reviews
-        if: ${{ !contains('OWNER,MEMBER,COLLABORATOR', github.event.pull_request.author_association) }}
         uses: withgraphite/dismiss-stale-approvals@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Prevents this action from dismissing the auto-approvals associated with dependabot. Without this, we have to manually approve on occasion. Example: https://github.com/solana-program/token-wrap/pull/126