### PR TITLE
Add confidential transfers test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9714,7 +9714,6 @@ dependencies = [
  "solana-program-pack",
  "solana-pubkey",
  "solana-rent",
- "solana-sdk-ids",
  "solana-system-interface",
  "solana-sysvar",
  "spl-associated-token-account-client",
@@ -9723,6 +9722,7 @@ dependencies = [
  "spl-token",
  "spl-token-2022 9.0.0",
  "spl-transfer-hook-interface",
+ "test-case",
  "test-transfer-hook",
  "thiserror 2.0.12",
 ]
@@ -10061,6 +10061,39 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "test-case"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8"
+dependencies = [
+ "test-case-macros",
+]
+
+[[package]]
+name = "test-case-core"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
+dependencies = [
+ "cfg-if 1.0.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "test-case-macros"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+ "test-case-core",
+]
 
 [[package]]
 name = "test-transfer-hook"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ spl-token-2022 = { version = "9.0.0", features = ["no-entrypoint"] }
 spl-token-wrap = { path = "program", features = ["no-entrypoint"] }
 spl-transfer-hook-interface = "0.10.0"
 tempfile = "3.20.0"
+test-case = "3.3.1"
 test-transfer-hook = { path = "program/tests/programs/test-transfer-hook", features = ["no-entrypoint"] }
 thiserror = "2.0.12"
 tokio = { version = "1.45.1", features = ["full"] }

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -40,8 +40,8 @@ spl-token-2022 = { workspace = true }
 mollusk-svm = { workspace = true }
 mollusk-svm-programs-token = { workspace = true }
 solana-account = { workspace = true }
-solana-sdk-ids = { workspace = true }
 spl-tlv-account-resolution = { workspace = true }
+test-case = { workspace = true }
 test-transfer-hook = { workspace = true }
 
 [lib]

--- a/program/tests/helpers/extensions.rs
+++ b/program/tests/helpers/extensions.rs
@@ -3,6 +3,7 @@ use {
     spl_pod::{optional_keys::OptionalNonZeroPubkey, primitives::PodU64},
     spl_token_2022::{
         extension::{
+            confidential_transfer::ConfidentialTransferMint,
             immutable_owner::ImmutableOwner,
             mint_close_authority::MintCloseAuthority,
             transfer_fee::{TransferFee, TransferFeeAmount, TransferFeeConfig},
@@ -15,6 +16,7 @@ use {
 
 #[derive(Clone, Debug)]
 pub enum MintExtension {
+    ConfidentialTransfer,
     TransferHook,
     TransferFeeConfig,
     MintCloseAuthority(Pubkey),
@@ -26,6 +28,7 @@ impl MintExtension {
             MintExtension::TransferHook => ExtensionType::TransferHook,
             MintExtension::TransferFeeConfig => ExtensionType::TransferFeeConfig,
             MintExtension::MintCloseAuthority(_) => ExtensionType::MintCloseAuthority,
+            MintExtension::ConfidentialTransfer => ExtensionType::ConfidentialTransferMint,
         }
     }
 }
@@ -70,6 +73,11 @@ pub fn init_mint_extensions(
                 let extension = state.init_extension::<MintCloseAuthority>(false).unwrap();
                 extension.close_authority =
                     OptionalNonZeroPubkey::try_from(Some(*authority)).unwrap();
+            }
+            MintExtension::ConfidentialTransfer => {
+                state
+                    .init_extension::<ConfidentialTransferMint>(false)
+                    .unwrap();
             }
         }
     }

--- a/program/tests/test_create_mint.rs
+++ b/program/tests/test_create_mint.rs
@@ -2,6 +2,8 @@ use {
     crate::helpers::{
         common::{TokenProgram, DEFAULT_MINT_DECIMALS},
         create_mint_builder::CreateMintBuilder,
+        extensions::MintExtension::ConfidentialTransfer,
+        mint_builder::MintBuilder,
     },
     mollusk_svm::result::Check,
     solana_account::Account,
@@ -274,4 +276,46 @@ fn test_successful_spl_token_2022_to_spl_token() {
     let backpointer =
         bytemuck::from_bytes::<Backpointer>(&result.wrapped_backpointer.account.data[..]);
     assert_eq!(backpointer.unwrapped_mint, unwrapped_mint_address);
+}
+
+#[test]
+fn test_create_mint_with_confidential_transfer() {
+    let unwrapped_mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken2022)
+        .with_extension(ConfidentialTransfer)
+        .build();
+
+    let result = CreateMintBuilder::default()
+        .unwrapped_mint_account(unwrapped_mint.account)
+        .unwrapped_mint_addr(unwrapped_mint.key)
+        .unwrapped_token_program(TokenProgram::SplToken2022)
+        .wrapped_token_program(TokenProgram::SplToken)
+        .execute();
+
+    assert_eq!(result.wrapped_mint.account.owner, spl_token::id());
+    let wrapped_mint_data =
+        PodStateWithExtensions::<PodMint>::unpack(&result.wrapped_mint.account.data)
+            .unwrap()
+            .base;
+
+    assert_eq!(wrapped_mint_data.decimals, DEFAULT_MINT_DECIMALS);
+    let expected_mint_authority = get_wrapped_mint_authority(&result.wrapped_mint.key);
+    assert_eq!(
+        wrapped_mint_data
+            .mint_authority
+            .ok_or(ProgramError::InvalidAccountData)
+            .unwrap(),
+        expected_mint_authority,
+    );
+    assert_eq!(wrapped_mint_data.supply, PodU64::from(0));
+    assert_eq!(wrapped_mint_data.is_initialized, PodBool::from_bool(true));
+    assert_eq!(wrapped_mint_data.freeze_authority, PodCOption::none());
+
+    assert_eq!(
+        result.wrapped_backpointer.account.owner,
+        spl_token_wrap::id()
+    );
+    let backpointer =
+        bytemuck::from_bytes::<Backpointer>(&result.wrapped_backpointer.account.data[..]);
+    assert_eq!(backpointer.unwrapped_mint, unwrapped_mint.key);
 }

--- a/program/tests/test_create_mint.rs
+++ b/program/tests/test_create_mint.rs
@@ -2,7 +2,7 @@ use {
     crate::helpers::{
         common::{TokenProgram, DEFAULT_MINT_DECIMALS},
         create_mint_builder::CreateMintBuilder,
-        extensions::MintExtension::ConfidentialTransfer,
+        extensions::MintExtension,
         mint_builder::MintBuilder,
     },
     mollusk_svm::result::Check,
@@ -22,6 +22,7 @@ use {
         error::TokenWrapError, get_wrapped_mint_address, get_wrapped_mint_authority,
         state::Backpointer,
     },
+    test_case::test_case,
 };
 
 pub mod helpers;
@@ -278,11 +279,14 @@ fn test_successful_spl_token_2022_to_spl_token() {
     assert_eq!(backpointer.unwrapped_mint, unwrapped_mint_address);
 }
 
-#[test]
-fn test_create_mint_with_confidential_transfer() {
+#[test_case(MintExtension::ConfidentialTransfer)]
+#[test_case(MintExtension::TransferHook)]
+#[test_case(MintExtension::TransferFeeConfig)]
+#[test_case(MintExtension::MintCloseAuthority(Pubkey::new_unique()))]
+fn test_create_mint_from_extended_mint(extension: MintExtension) {
     let unwrapped_mint = MintBuilder::new()
         .token_program(TokenProgram::SplToken2022)
-        .with_extension(ConfidentialTransfer)
+        .with_extension(extension)
         .build();
 
     let result = CreateMintBuilder::default()

--- a/program/tests/test_wrap.rs
+++ b/program/tests/test_wrap.rs
@@ -5,7 +5,9 @@ use {
             TokenProgram, DEFAULT_MINT_SUPPLY,
         },
         create_mint_builder::CreateMintBuilder,
-        extensions::MintExtension::{TransferFeeConfig as MintTransferFeeConfig, TransferHook},
+        extensions::MintExtension::{
+            ConfidentialTransfer, TransferFeeConfig as MintTransferFeeConfig, TransferHook,
+        },
         mint_builder::MintBuilder,
         token_account_builder::TokenAccountBuilder,
         wrap_builder::{WrapBuilder, WrapResult},
@@ -405,4 +407,25 @@ fn wrap_with_transfer_fee() {
         u64::from(escrow_transfer_fee_amount_ext.withheld_amount),
         fee
     );
+}
+
+#[test]
+fn test_wrap_with_confidential_transfer_mint() {
+    let starting_amount = 50_000;
+    let wrap_amount = 12_555;
+
+    let unwrapped_mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken2022)
+        .with_extension(ConfidentialTransfer)
+        .build();
+
+    let wrap_result = WrapBuilder::default()
+        .unwrapped_token_program(TokenProgram::SplToken2022)
+        .wrapped_token_program(TokenProgram::SplToken2022)
+        .recipient_starting_amount(starting_amount)
+        .wrap_amount(wrap_amount)
+        .unwrapped_mint(unwrapped_mint)
+        .execute();
+
+    assert_wrap_result(starting_amount, wrap_amount, &wrap_result);
 }


### PR DESCRIPTION
Closes https://github.com/solana-program/token-wrap/issues/141, reported @cryptopapi997

Ensures CreateMint/Wrap/Unwrap support for mints with the confidential transfers extension. 

