### PR TITLE
Toolchain bump to 1.85

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.84.1"
+channel = "1.85.0"


### PR DESCRIPTION
Release of cargo-semver-checks [v0.42.0](https://github.com/obi1kenobi/cargo-semver-checks/releases/tag/v0.42.0) requires toolchain bump

See failure https://github.com/solana-program/token-wrap/actions/runs/16113290466/job/45461472585?pr=167
