### PR TITLE
Update ImmutableOwner check

### DIFF
--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -444,7 +444,9 @@ pub fn process_close_stuck_escrow(accounts: &[AccountInfo]) -> ProgramResult {
         ExtensionType::get_required_init_account_extensions(&mint_extensions);
 
     // ATAs always have the ImmutableOwner extension
-    required_account_extensions.push(ExtensionType::ImmutableOwner);
+    if !required_account_extensions.contains(&ExtensionType::ImmutableOwner) {
+        required_account_extensions.push(ExtensionType::ImmutableOwner);
+    }
 
     // If the token account already shares the same extensions as the mint,
     // it does not need to be re-created

--- a/program/tests/helpers/extensions.rs
+++ b/program/tests/helpers/extensions.rs
@@ -6,6 +6,7 @@ use {
             confidential_transfer::ConfidentialTransferMint,
             immutable_owner::ImmutableOwner,
             mint_close_authority::MintCloseAuthority,
+            non_transferable::{NonTransferable, NonTransferableAccount},
             transfer_fee::{TransferFee, TransferFeeAmount, TransferFeeConfig},
             transfer_hook::{TransferHook, TransferHookAccount},
             BaseStateWithExtensionsMut, ExtensionType, PodStateWithExtensionsMut,
@@ -20,6 +21,7 @@ pub enum MintExtension {
     TransferHook,
     TransferFeeConfig,
     MintCloseAuthority(Pubkey),
+    NonTransferable,
 }
 
 impl MintExtension {
@@ -29,6 +31,7 @@ impl MintExtension {
             MintExtension::TransferFeeConfig => ExtensionType::TransferFeeConfig,
             MintExtension::MintCloseAuthority(_) => ExtensionType::MintCloseAuthority,
             MintExtension::ConfidentialTransfer => ExtensionType::ConfidentialTransferMint,
+            MintExtension::NonTransferable => ExtensionType::NonTransferable,
         }
     }
 }
@@ -79,6 +82,9 @@ pub fn init_mint_extensions(
                     .init_extension::<ConfidentialTransferMint>(false)
                     .unwrap();
             }
+            MintExtension::NonTransferable => {
+                state.init_extension::<NonTransferable>(false).unwrap();
+            }
         }
     }
 }
@@ -101,6 +107,11 @@ pub fn init_token_account_extensions(
             }
             ExtensionType::TransferHookAccount => {
                 state.init_extension::<TransferHookAccount>(true).unwrap();
+            }
+            ExtensionType::NonTransferableAccount => {
+                state
+                    .init_extension::<NonTransferableAccount>(true)
+                    .unwrap();
             }
             _ => unimplemented!(),
         }


### PR DESCRIPTION
Audit remediation. For `NonTransferable` extension (and possibly others in the future), the `ImmutableOwner` extension is required on the token account. The current logic indiscriminately already adds `ImmutableOwner` to the vec check given ATAs require them. This means there is a duplicate that would result and cause the escrow to close despite being valid.

This PR fixes that issue by only adding `ImmutableOwner` if not present.