### PR TITLE
Sync metadata to token-2022 pt. 1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9757,6 +9757,7 @@ dependencies = [
  "spl-token-2022 9.0.0",
  "spl-token-metadata-interface",
  "spl-transfer-hook-interface",
+ "spl-type-length-value",
  "test-case",
  "test-transfer-hook",
  "thiserror 2.0.12",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ level = "warn"
 check-cfg = [
     'cfg(target_os, values("solana"))',
     'cfg(feature, values("frozen-abi", "no-entrypoint"))',
+    'cfg(feature, values("custom-heap", "custom-panic"))',
 ]
 
 [workspace.package]
@@ -77,6 +78,7 @@ spl-token-2022 = { version = "9.0.0", features = ["no-entrypoint"] }
 spl-token-metadata-interface = "0.7.0"
 spl-token-wrap = { path = "program", features = ["no-entrypoint"] }
 spl-transfer-hook-interface = "0.10.0"
+spl-type-length-value = "0.8.0"
 tempfile = "3.20.0"
 test-case = "3.3.1"
 test-transfer-hook = { path = "program/tests/programs/test-transfer-hook", features = ["no-entrypoint"] }

--- a/clients/cli/src/create_mint.rs
+++ b/clients/cli/src/create_mint.rs
@@ -16,8 +16,7 @@ use {
     solana_transaction::Transaction,
     spl_token::solana_program::program_pack::Pack,
     spl_token_wrap::{
-        get_wrapped_mint_address, get_wrapped_mint_authority, get_wrapped_mint_backpointer_address,
-        id,
+        get_wrapped_mint_address, get_wrapped_mint_backpointer_address, id,
         instruction::create_mint,
         mint_customizer::{
             default_token_2022::DefaultToken2022Customizer, interface::MintCustomizer,
@@ -123,7 +122,7 @@ pub async fn command_create_mint(config: &Config, args: CreateMintArgs) -> Comma
     };
 
     let mint_size = if args.wrapped_token_program == spl_token_2022::id() {
-        DefaultToken2022Customizer::get_token_2022_total_space()?
+        DefaultToken2022Customizer::get_token_2022_mint_space()?
     } else {
         spl_token::state::Mint::LEN
     };
@@ -177,13 +176,11 @@ pub async fn command_create_mint(config: &Config, args: CreateMintArgs) -> Comma
     }
 
     // Add the create_mint instruction
-    let wrapped_mint_authority_address = get_wrapped_mint_authority(&wrapped_mint_address);
     instructions.push(create_mint(
         &id(),
         &wrapped_mint_address,
         &wrapped_backpointer_address,
         &args.unwrapped_mint,
-        &wrapped_mint_authority_address,
         &args.wrapped_token_program,
         args.idempotent,
     ));

--- a/clients/cli/tests/test_create_mint.rs
+++ b/clients/cli/tests/test_create_mint.rs
@@ -11,7 +11,6 @@ use {
         },
         pod::PodMint,
     },
-    spl_token_metadata_interface::state::TokenMetadata,
     spl_token_wrap::{
         self, get_wrapped_mint_address, get_wrapped_mint_authority,
         get_wrapped_mint_backpointer_address, state::Backpointer,
@@ -65,7 +64,7 @@ async fn test_create_mint() {
     assert_eq!(backpointer.unwrapped_mint, unwrapped_mint);
 
     // Verify extension state
-    assert_eq!(wrapped_mint_state.get_extension_types().unwrap().len(), 3);
+    assert_eq!(wrapped_mint_state.get_extension_types().unwrap().len(), 2);
 
     assert!(wrapped_mint_state
         .get_extension::<ConfidentialTransferMint>()
@@ -84,14 +83,4 @@ async fn test_create_mint() {
         Option::<Pubkey>::from(pointer_ext.metadata_address).unwrap(),
         wrapped_mint_address
     );
-
-    // Verify TokenMetadata content
-    let metadata_ext = wrapped_mint_state
-        .get_variable_len_extension::<TokenMetadata>()
-        .unwrap();
-    assert_eq!(
-        Option::<Pubkey>::from(metadata_ext.update_authority).unwrap(),
-        expected_mint_authority
-    );
-    assert_eq!(metadata_ext.mint, wrapped_mint_address);
 }

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -41,6 +41,7 @@ spl-token-2022 = { workspace = true }
 mollusk-svm = { workspace = true }
 mollusk-svm-programs-token = { workspace = true }
 solana-account = { workspace = true }
+spl-type-length-value = { workspace = true }
 spl-tlv-account-resolution = { workspace = true }
 test-case = { workspace = true }
 test-transfer-hook = { workspace = true }

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -42,6 +42,9 @@ pub enum TokenWrapError {
     /// The escrow account is in a good state and cannot be recreated
     #[error("The escrow account is in a good state and cannot be recreated")]
     EscrowInGoodState,
+    /// Unwrapped mint does not have the `TokenMetadata` extension
+    #[error("Unwrapped mint does not have the TokenMetadata extension")]
+    UnwrappedMintHasNoMetadata,
 }
 
 impl From<TokenWrapError> for ProgramError {
@@ -73,6 +76,7 @@ impl ToStr for TokenWrapError {
             TokenWrapError::InvalidBackpointerOwner => "Error: InvalidBackpointerOwner",
             TokenWrapError::EscrowMismatch => "Error: EscrowMismatch",
             TokenWrapError::EscrowInGoodState => "Error: EscrowInGoodState",
+            TokenWrapError::UnwrappedMintHasNoMetadata => "Error: UnwrappedMintHasNoMetadata",
         }
     }
 }

--- a/program/src/mint_customizer/interface.rs
+++ b/program/src/mint_customizer/interface.rs
@@ -8,34 +8,17 @@ use {
 pub trait MintCustomizer {
     /// Calculates the space required for a new spl-token-2022 mint
     /// account, including any custom extensions
-    fn get_token_2022_mint_initialization_space() -> Result<usize, ProgramError>;
-
-    /// Calculates the total space required for a new spl-token-2022
-    /// mint, after `post_initialize_extensions()` is called. This is useful in
-    /// calculating rent requirements if something like `TokenMetadata` does a
-    /// realloc after the mint is created. If not implemented, defaults to
-    /// `get_token_2022_mint_initialization_space()` result.
-    fn get_token_2022_total_space() -> Result<usize, ProgramError> {
-        Self::get_token_2022_mint_initialization_space()
-    }
+    fn get_token_2022_mint_space() -> Result<usize, ProgramError>;
 
     /// Customizes extensions for the wrapped mint *before* the base mint is
     /// initialized. This is for extensions that must be initialized on an
     /// uninitialized mint account, like `ConfidentialTransferMint`.
-    fn pre_initialize_extensions(
-        wrapped_mint_account: &AccountInfo,
-        wrapped_token_program_account: &AccountInfo,
-    ) -> ProgramResult;
-
-    /// Customizes extensions for the wrapped mint *after* the base mint is
-    /// initialized. This is for extensions that require the mint to be
-    /// initialized, like `TokenMetadata`.
-    fn post_initialize_extensions<'a>(
-        wrapped_mint_account: &AccountInfo<'a>,
-        wrapped_token_program_account: &AccountInfo,
-        wrapped_mint_authority_account: &AccountInfo<'a>,
-        mint_authority_signer_seeds: &[&[u8]],
-    ) -> ProgramResult;
+    fn initialize_extensions(
+        _wrapped_mint_account: &AccountInfo,
+        _wrapped_token_program_account: &AccountInfo,
+    ) -> ProgramResult {
+        Ok(())
+    }
 
     /// Customize the freeze authority and decimals for the wrapped mint
     fn get_freeze_auth_and_decimals(

--- a/program/src/mint_customizer/no_extensions.rs
+++ b/program/src/mint_customizer/no_extensions.rs
@@ -1,7 +1,7 @@
 use {
     crate::mint_customizer::interface::MintCustomizer,
     solana_account_info::AccountInfo,
-    solana_program_error::{ProgramError, ProgramResult},
+    solana_program_error::ProgramError,
     solana_pubkey::Pubkey,
     spl_token_2022::{
         extension::{ExtensionType, PodStateWithExtensions},
@@ -14,25 +14,9 @@ use {
 pub struct NoExtensionCustomizer;
 
 impl MintCustomizer for NoExtensionCustomizer {
-    fn get_token_2022_mint_initialization_space() -> Result<usize, ProgramError> {
+    fn get_token_2022_mint_space() -> Result<usize, ProgramError> {
         let extensions = vec![];
         ExtensionType::try_calculate_account_len::<Mint>(&extensions)
-    }
-
-    fn pre_initialize_extensions(
-        _wrapped_mint_account: &AccountInfo,
-        _wrapped_token_program_account: &AccountInfo,
-    ) -> ProgramResult {
-        Ok(())
-    }
-
-    fn post_initialize_extensions<'a>(
-        _wrapped_mint_account: &AccountInfo<'a>,
-        _wrapped_token_program_account: &AccountInfo,
-        _wrapped_mint_authority_account: &AccountInfo<'a>,
-        _mint_authority_signer_seeds: &[&[u8]],
-    ) -> ProgramResult {
-        Ok(())
     }
 
     fn get_freeze_auth_and_decimals(

--- a/program/tests/helpers/create_mint_builder.rs
+++ b/program/tests/helpers/create_mint_builder.rs
@@ -7,8 +7,7 @@ use {
     solana_account::Account,
     solana_pubkey::Pubkey,
     spl_token_wrap::{
-        get_wrapped_mint_address, get_wrapped_mint_authority, get_wrapped_mint_backpointer_address,
-        instruction::create_mint,
+        get_wrapped_mint_address, get_wrapped_mint_backpointer_address, instruction::create_mint,
     },
 };
 
@@ -27,7 +26,6 @@ pub struct CreateMintBuilder<'a> {
     unwrapped_token_program: TokenProgram,
     wrapped_mint_addr: Option<Pubkey>,
     wrapped_mint_account: Option<Account>,
-    wrapped_mint_authority_addr: Option<Pubkey>,
     backpointer_addr: Option<Pubkey>,
     backpointer_account: Option<Account>,
     freeze_authority: Option<Pubkey>,
@@ -46,7 +44,6 @@ impl Default for CreateMintBuilder<'_> {
             unwrapped_token_program: TokenProgram::SplToken,
             wrapped_mint_addr: None,
             wrapped_mint_account: None,
-            wrapped_mint_authority_addr: None,
             backpointer_addr: None,
             backpointer_account: None,
             freeze_authority: None,
@@ -84,11 +81,6 @@ impl<'a> CreateMintBuilder<'a> {
 
     pub fn wrapped_mint_account(mut self, account: Account) -> Self {
         self.wrapped_mint_account = Some(account);
-        self
-    }
-
-    pub fn wrapped_mint_authority_addr(mut self, key: Pubkey) -> Self {
-        self.wrapped_mint_authority_addr = Some(key);
         self
     }
 
@@ -157,16 +149,11 @@ impl<'a> CreateMintBuilder<'a> {
             ..Default::default()
         });
 
-        let wrapped_mint_authority_address = self
-            .wrapped_mint_authority_addr
-            .unwrap_or_else(|| get_wrapped_mint_authority(&wrapped_mint_addr));
-
         let instruction = create_mint(
             &spl_token_wrap::id(),
             &wrapped_mint_addr,
             &wrapped_backpointer_address,
             &unwrapped_mint_addr,
-            &wrapped_mint_authority_address,
             &wrapped_token_program_id,
             self.idempotent,
         );
@@ -181,7 +168,6 @@ impl<'a> CreateMintBuilder<'a> {
             (wrapped_mint_addr, wrapped_mint_account),
             (wrapped_backpointer_address, wrapped_backpointer_account),
             (unwrapped_mint_addr, unwrapped_mint_account),
-            (wrapped_mint_authority_address, Account::default()),
             keyed_account_for_system_program(),
             keyed_token_program,
         ];

--- a/program/tests/helpers/extensions.rs
+++ b/program/tests/helpers/extensions.rs
@@ -1,4 +1,5 @@
 use {
+    solana_program_pack::Pack,
     solana_pubkey::Pubkey,
     spl_pod::{optional_keys::OptionalNonZeroPubkey, primitives::PodU64},
     spl_token_2022::{
@@ -9,10 +10,15 @@ use {
             non_transferable::{NonTransferable, NonTransferableAccount},
             transfer_fee::{TransferFee, TransferFeeAmount, TransferFeeConfig},
             transfer_hook::{TransferHook, TransferHookAccount},
-            BaseStateWithExtensionsMut, ExtensionType, PodStateWithExtensionsMut,
+            AccountType, BaseStateWithExtensionsMut, ExtensionType, Length,
+            PodStateWithExtensionsMut,
         },
         pod::{PodAccount, PodMint},
+        state::{Account, Mint},
     },
+    spl_token_metadata_interface::state::TokenMetadata,
+    spl_token_wrap::get_wrapped_mint_authority,
+    spl_type_length_value::variable_len_pack::VariableLenPack,
 };
 
 #[derive(Clone, Debug)]
@@ -22,6 +28,13 @@ pub enum MintExtension {
     TransferFeeConfig,
     MintCloseAuthority(Pubkey),
     NonTransferable,
+    TokenMetadata {
+        name: String,
+        symbol: String,
+        uri: String,
+        additional_metadata: Vec<(String, String)>,
+    },
+    MetadataPointer,
 }
 
 impl MintExtension {
@@ -32,6 +45,8 @@ impl MintExtension {
             MintExtension::MintCloseAuthority(_) => ExtensionType::MintCloseAuthority,
             MintExtension::ConfidentialTransfer => ExtensionType::ConfidentialTransferMint,
             MintExtension::NonTransferable => ExtensionType::NonTransferable,
+            MintExtension::TokenMetadata { .. } => ExtensionType::TokenMetadata,
+            MintExtension::MetadataPointer => ExtensionType::MetadataPointer,
         }
     }
 }
@@ -40,6 +55,7 @@ impl MintExtension {
 pub fn init_mint_extensions(
     state: &mut PodStateWithExtensionsMut<PodMint>,
     extensions: &[MintExtension],
+    mint_key: &Pubkey,
 ) {
     for extension in extensions {
         match extension {
@@ -85,6 +101,35 @@ pub fn init_mint_extensions(
             MintExtension::NonTransferable => {
                 state.init_extension::<NonTransferable>(false).unwrap();
             }
+            MintExtension::TokenMetadata {
+                name,
+                symbol,
+                uri,
+                additional_metadata,
+            } => {
+                let wrapped_mint_authority = get_wrapped_mint_authority(mint_key);
+                let token_metadata = TokenMetadata {
+                    update_authority: Some(wrapped_mint_authority).try_into().unwrap(),
+                    mint: *mint_key,
+                    name: name.clone(),
+                    symbol: symbol.clone(),
+                    uri: uri.clone(),
+                    additional_metadata: additional_metadata.clone(),
+                };
+                state
+                    .init_variable_len_extension::<TokenMetadata>(&token_metadata, false)
+                    .unwrap();
+            }
+            MintExtension::MetadataPointer => {
+                let wrapped_mint_authority = get_wrapped_mint_authority(mint_key);
+                let extension = state
+                    .init_extension::<spl_token_2022::extension::metadata_pointer::MetadataPointer>(
+                        false,
+                    )
+                    .unwrap();
+                extension.authority = Some(wrapped_mint_authority).try_into().unwrap();
+                extension.metadata_address = Some(*mint_key).try_into().unwrap();
+            }
         }
     }
 }
@@ -116,4 +161,68 @@ pub fn init_token_account_extensions(
             _ => unimplemented!(),
         }
     }
+}
+
+/// Calculate the exact mint account length including all extensions
+pub fn calc_mint_len(mint_key: &Pubkey, extensions: &[MintExtension]) -> usize {
+    if extensions.is_empty() {
+        return Mint::LEN;
+    }
+
+    // Partition extensions into fixed-length and variable-length
+    let (variable_len_extensions, fixed_len_extensions): (
+        Vec<&MintExtension>,
+        Vec<&MintExtension>,
+    ) = extensions
+        .iter()
+        .partition(|e| matches!(e, MintExtension::TokenMetadata { .. }));
+
+    let fixed_len_extension_types: Vec<ExtensionType> = fixed_len_extensions
+        .iter()
+        .map(|e| e.extension_type())
+        .collect();
+
+    // 1. Start with the size required for all fixed-length extensions.
+    let mut len =
+        ExtensionType::try_calculate_account_len::<Mint>(&fixed_len_extension_types).unwrap();
+
+    // 2. If there were no fixed extensions, but there are variable extensions,
+    // we need to account for the base padding and AccountType byte
+    if fixed_len_extensions.is_empty() && !variable_len_extensions.is_empty() {
+        len = Account::LEN.checked_add(size_of::<AccountType>()).unwrap();
+    }
+
+    // 3. Add size of variable-length extensions
+    for extension in variable_len_extensions {
+        let value_len = match extension {
+            MintExtension::TokenMetadata {
+                name,
+                symbol,
+                uri,
+                additional_metadata,
+            } => {
+                let wrapped_mint_authority = get_wrapped_mint_authority(mint_key);
+                let tm = TokenMetadata {
+                    update_authority: Some(wrapped_mint_authority).try_into().unwrap(),
+                    mint: *mint_key,
+                    name: name.clone(),
+                    symbol: symbol.clone(),
+                    uri: uri.clone(),
+                    additional_metadata: additional_metadata.clone(),
+                };
+                tm.get_packed_len().unwrap()
+            }
+            _ => panic!("should not happen due to partitioning"),
+        };
+
+        len = len
+            .checked_add(size_of::<ExtensionType>())
+            .unwrap()
+            .checked_add(size_of::<Length>())
+            .unwrap()
+            .checked_add(value_len)
+            .unwrap();
+    }
+
+    len
 }

--- a/program/tests/helpers/mod.rs
+++ b/program/tests/helpers/mod.rs
@@ -3,6 +3,7 @@ pub mod common;
 pub mod create_mint_builder;
 pub mod extensions;
 pub mod mint_builder;
+pub mod sync_metadata_builder;
 pub mod token_account_builder;
 pub mod unwrap_builder;
 pub mod wrap_builder;

--- a/program/tests/helpers/sync_metadata_builder.rs
+++ b/program/tests/helpers/sync_metadata_builder.rs
@@ -1,0 +1,128 @@
+use {
+    crate::helpers::{
+        common::{init_mollusk, KeyedAccount, TokenProgram},
+        extensions::MintExtension,
+        mint_builder::MintBuilder,
+    },
+    mollusk_svm::{result::Check, Mollusk},
+    solana_account::Account,
+    solana_pubkey::Pubkey,
+    spl_token_wrap::{
+        get_wrapped_mint_address, get_wrapped_mint_authority,
+        instruction::sync_metadata_to_token_2022,
+    },
+};
+
+pub struct SyncMetadataResult {
+    pub unwrapped_mint: KeyedAccount,
+    pub wrapped_mint: KeyedAccount,
+}
+
+pub struct SyncMetadataBuilder<'a> {
+    mollusk: Mollusk,
+    checks: Vec<Check<'a>>,
+    unwrapped_mint: Option<KeyedAccount>,
+    wrapped_mint: Option<KeyedAccount>,
+    wrapped_mint_authority: Option<Pubkey>,
+}
+
+impl Default for SyncMetadataBuilder<'_> {
+    fn default() -> Self {
+        Self {
+            mollusk: init_mollusk(),
+            checks: Vec::new(),
+            unwrapped_mint: None,
+            wrapped_mint: None,
+            wrapped_mint_authority: None,
+        }
+    }
+}
+
+impl<'a> SyncMetadataBuilder<'a> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn unwrapped_mint(mut self, account: KeyedAccount) -> Self {
+        self.unwrapped_mint = Some(account);
+        self
+    }
+
+    pub fn wrapped_mint(mut self, account: KeyedAccount) -> Self {
+        self.wrapped_mint = Some(account);
+        self
+    }
+
+    pub fn wrapped_mint_authority(mut self, authority: Pubkey) -> Self {
+        self.wrapped_mint_authority = Some(authority);
+        self
+    }
+
+    pub fn check(mut self, check: Check<'a>) -> Self {
+        self.checks.push(check);
+        self
+    }
+
+    pub fn execute(mut self) -> SyncMetadataResult {
+        let unwrapped_mint = self.unwrapped_mint.unwrap_or_else(|| {
+            MintBuilder::new()
+                .token_program(TokenProgram::SplToken2022)
+                .with_extension(MintExtension::TokenMetadata {
+                    name: "Unwrapped".to_string(),
+                    symbol: "UP".to_string(),
+                    uri: "uri://unwrapped.com".to_string(),
+                    additional_metadata: vec![],
+                })
+                .build()
+        });
+
+        let wrapped_mint_address =
+            get_wrapped_mint_address(&unwrapped_mint.key, &spl_token_2022::id());
+
+        let wrapped_mint_authority = self
+            .wrapped_mint_authority
+            .unwrap_or_else(|| get_wrapped_mint_authority(&wrapped_mint_address));
+
+        let wrapped_mint = self.wrapped_mint.unwrap_or_else(|| {
+            MintBuilder::new()
+                .token_program(TokenProgram::SplToken2022)
+                .mint_key(wrapped_mint_address)
+                .mint_authority(wrapped_mint_authority)
+                .lamports(1_000_000_000) // Add sufficient lamports for rent
+                .build()
+        });
+
+        let instruction = sync_metadata_to_token_2022(
+            &spl_token_wrap::id(),
+            &wrapped_mint.key,
+            &wrapped_mint_authority,
+            &unwrapped_mint.key,
+        );
+
+        let accounts = &[
+            wrapped_mint.pair(),
+            (wrapped_mint_authority, Account::default()),
+            unwrapped_mint.pair(),
+            TokenProgram::SplToken2022.keyed_account(),
+        ];
+
+        if self.checks.is_empty() {
+            self.checks.push(Check::success());
+        }
+
+        let result =
+            self.mollusk
+                .process_and_validate_instruction(&instruction, accounts, &self.checks);
+
+        SyncMetadataResult {
+            unwrapped_mint: KeyedAccount {
+                key: unwrapped_mint.key,
+                account: result.get_account(&unwrapped_mint.key).unwrap().clone(),
+            },
+            wrapped_mint: KeyedAccount {
+                key: wrapped_mint.key,
+                account: result.get_account(&wrapped_mint.key).unwrap().clone(),
+            },
+        }
+    }
+}

--- a/program/tests/helpers/sync_metadata_builder.rs
+++ b/program/tests/helpers/sync_metadata_builder.rs
@@ -16,6 +16,7 @@ use {
 pub struct SyncMetadataResult {
     pub unwrapped_mint: KeyedAccount,
     pub wrapped_mint: KeyedAccount,
+    pub wrapped_mint_authority: KeyedAccount,
 }
 
 pub struct SyncMetadataBuilder<'a> {
@@ -122,6 +123,10 @@ impl<'a> SyncMetadataBuilder<'a> {
             wrapped_mint: KeyedAccount {
                 key: wrapped_mint.key,
                 account: result.get_account(&wrapped_mint.key).unwrap().clone(),
+            },
+            wrapped_mint_authority: KeyedAccount {
+                key: wrapped_mint_authority,
+                account: result.get_account(&wrapped_mint_authority).unwrap().clone(),
             },
         }
     }

--- a/program/tests/test_create_mint.rs
+++ b/program/tests/test_create_mint.rs
@@ -19,14 +19,13 @@ use {
             BaseStateWithExtensions,
             ExtensionType::{
                 ConfidentialTransferMint as ConfidentialTransferMintExt,
-                MetadataPointer as MetadataPointerExt, TokenMetadata as TokenMetadataExt,
+                MetadataPointer as MetadataPointerExt,
             },
             PodStateWithExtensions,
         },
         pod::PodMint,
         state::Mint,
     },
-    spl_token_metadata_interface::state::TokenMetadata,
     spl_token_wrap::{
         error::TokenWrapError, get_wrapped_mint_address, get_wrapped_mint_authority,
         state::Backpointer,
@@ -179,14 +178,6 @@ fn test_improperly_derived_addresses_fail() {
     CreateMintBuilder::default()
         .token_program_addr(incorrect_token_program)
         .check(Check::err(ProgramError::IncorrectProgramId))
-        .execute();
-}
-
-#[test]
-fn test_fails_with_incorrect_wrapped_mint_authority() {
-    CreateMintBuilder::default()
-        .wrapped_mint_authority_addr(Pubkey::new_unique()) // wrong addr
-        .check(Check::err(TokenWrapError::MintAuthorityMismatch.into()))
         .execute();
 }
 
@@ -369,10 +360,9 @@ fn test_customizer_applies_all_default_extensions() {
         PodStateWithExtensions::<PodMint>::unpack(&result.wrapped_mint.account.data).unwrap();
 
     let extensions = wrapped_mint_state.get_extension_types().unwrap();
-    assert_eq!(extensions.len(), 3);
+    assert_eq!(extensions.len(), 2);
     assert!(extensions.contains(&ConfidentialTransferMintExt));
     assert!(extensions.contains(&MetadataPointerExt));
-    assert!(extensions.contains(&TokenMetadataExt));
 
     assert!(wrapped_mint_state
         .get_extension::<ConfidentialTransferMint>()
@@ -391,14 +381,4 @@ fn test_customizer_applies_all_default_extensions() {
         Option::<Pubkey>::from(pointer_ext.metadata_address).unwrap(),
         result.wrapped_mint.key
     );
-
-    // Verify TokenMetadata content
-    let metadata_ext = wrapped_mint_state
-        .get_variable_len_extension::<TokenMetadata>()
-        .unwrap();
-    assert_eq!(
-        Option::<Pubkey>::from(metadata_ext.update_authority).unwrap(),
-        expected_mint_authority
-    );
-    assert_eq!(metadata_ext.mint, result.wrapped_mint.key);
 }

--- a/program/tests/test_instruction.rs
+++ b/program/tests/test_instruction.rs
@@ -40,7 +40,7 @@ fn test_pack_unpack_unwrap() {
 #[test]
 fn test_unpack_invalid_data() {
     assert!(TokenWrapInstruction::unpack(&[]).is_err());
-    assert!(TokenWrapInstruction::unpack(&[4]).is_err());
+    assert!(TokenWrapInstruction::unpack(&[5]).is_err());
     assert!(TokenWrapInstruction::unpack(&[0]).is_err());
     assert!(TokenWrapInstruction::unpack(&[1, 0, 0, 0]).is_err());
     assert!(TokenWrapInstruction::unpack(&[2, 0, 0, 0]).is_err());

--- a/program/tests/test_stuck_escrow.rs
+++ b/program/tests/test_stuck_escrow.rs
@@ -449,7 +449,6 @@ fn test_end_to_end_close_mint_case() {
         &wrapped_mint_address,
         &backpointer_address,
         &unwrapped_mint.key,
-        &wrapped_mint_authority,
         &spl_token_2022::id(),
         false,
     );

--- a/program/tests/test_sync_metadata_to_token_2022.rs
+++ b/program/tests/test_sync_metadata_to_token_2022.rs
@@ -48,7 +48,7 @@ fn test_success_initialize_metadata() {
 
     let result = SyncMetadataBuilder::new()
         .unwrapped_mint(unwrapped_mint)
-        .wrapped_mint(wrapped_mint)
+        .wrapped_mint(wrapped_mint.clone())
         .execute();
 
     let wrapped_mint_state =
@@ -68,6 +68,11 @@ fn test_success_initialize_metadata() {
         assert_eq!(wrapped_metadata.symbol, symbol);
         assert_eq!(wrapped_metadata.uri, uri);
         assert_eq!(wrapped_metadata.additional_metadata, additional_metadata);
+        assert_eq!(
+            Option::<Pubkey>::from(wrapped_metadata.update_authority).unwrap(),
+            wrapped_mint_authority
+        );
+        assert_eq!(wrapped_metadata.mint, wrapped_mint.key);
     } else {
         panic!("destructure failed");
     }
@@ -105,7 +110,7 @@ fn test_success_initialize_metadata_with_additional_fields() {
 
     let result = SyncMetadataBuilder::new()
         .unwrapped_mint(unwrapped_mint)
-        .wrapped_mint(wrapped_mint)
+        .wrapped_mint(wrapped_mint.clone())
         .execute();
 
     let wrapped_mint_state =
@@ -125,6 +130,11 @@ fn test_success_initialize_metadata_with_additional_fields() {
         assert_eq!(wrapped_metadata.symbol, symbol);
         assert_eq!(wrapped_metadata.uri, uri);
         assert_eq!(wrapped_metadata.additional_metadata, additional_metadata);
+        assert_eq!(
+            Option::<Pubkey>::from(wrapped_metadata.update_authority).unwrap(),
+            result.wrapped_mint_authority.key
+        );
+        assert_eq!(wrapped_metadata.mint, wrapped_mint.key);
     } else {
         panic!("destructure failed");
     }
@@ -166,7 +176,7 @@ fn test_success_update_metadata() {
 
     let result = SyncMetadataBuilder::new()
         .unwrapped_mint(unwrapped_mint)
-        .wrapped_mint(wrapped_mint)
+        .wrapped_mint(wrapped_mint.clone())
         .execute();
 
     let wrapped_mint_state =
@@ -186,6 +196,11 @@ fn test_success_update_metadata() {
         assert_eq!(wrapped_metadata.symbol, symbol);
         assert_eq!(wrapped_metadata.uri, uri);
         assert_eq!(wrapped_metadata.additional_metadata, additional_metadata);
+        assert_eq!(
+            Option::<Pubkey>::from(wrapped_metadata.update_authority).unwrap(),
+            result.wrapped_mint_authority.key
+        );
+        assert_eq!(wrapped_metadata.mint, wrapped_mint.key);
     } else {
         panic!("destructure failed");
     }
@@ -230,7 +245,7 @@ fn test_success_update_metadata_with_additional_fields() {
 
     let result = SyncMetadataBuilder::new()
         .unwrapped_mint(unwrapped_mint)
-        .wrapped_mint(wrapped_mint)
+        .wrapped_mint(wrapped_mint.clone())
         .execute();
 
     let wrapped_mint_state =
@@ -250,6 +265,11 @@ fn test_success_update_metadata_with_additional_fields() {
         assert_eq!(wrapped_metadata.symbol, symbol);
         assert_eq!(wrapped_metadata.uri, uri);
         assert_eq!(wrapped_metadata.additional_metadata, additional_metadata);
+        assert_eq!(
+            Option::<Pubkey>::from(wrapped_metadata.update_authority).unwrap(),
+            result.wrapped_mint_authority.key
+        );
+        assert_eq!(wrapped_metadata.mint, wrapped_mint.key);
     } else {
         panic!("destructure failed");
     }

--- a/program/tests/test_sync_metadata_to_token_2022.rs
+++ b/program/tests/test_sync_metadata_to_token_2022.rs
@@ -1,0 +1,380 @@
+use {
+    crate::helpers::{
+        common::{init_mollusk, KeyedAccount, TokenProgram},
+        extensions::{MintExtension, MintExtension::MetadataPointer as MetadataPointerExt},
+        mint_builder::MintBuilder,
+        sync_metadata_builder::SyncMetadataBuilder,
+    },
+    mollusk_svm::{program::create_program_account_loader_v3, result::Check},
+    solana_account::Account,
+    solana_instruction::{AccountMeta, Instruction},
+    solana_program_error::ProgramError,
+    solana_pubkey::Pubkey,
+    spl_token_2022::{
+        extension::{BaseStateWithExtensions, PodStateWithExtensions},
+        pod::PodMint,
+    },
+    spl_token_metadata_interface::state::TokenMetadata,
+    spl_token_wrap::{
+        error::TokenWrapError, get_wrapped_mint_address, get_wrapped_mint_authority, id,
+        instruction::TokenWrapInstruction,
+    },
+};
+
+pub mod helpers;
+
+#[test]
+fn test_success_initialize_metadata() {
+    let unwrapped_metadata = MintExtension::TokenMetadata {
+        name: "Unwrapped Token".to_string(),
+        symbol: "UWT".to_string(),
+        uri: "https://unwrapped.dev/meta.json".to_string(),
+        additional_metadata: vec![],
+    };
+    let unwrapped_mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken2022)
+        .with_extension(unwrapped_metadata.clone())
+        .build();
+
+    let wrapped_mint_address = get_wrapped_mint_address(&unwrapped_mint.key, &spl_token_2022::id());
+    let wrapped_mint_authority = get_wrapped_mint_authority(&wrapped_mint_address);
+    let wrapped_mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken2022)
+        .mint_key(wrapped_mint_address)
+        .mint_authority(wrapped_mint_authority)
+        .with_extension(MetadataPointerExt)
+        .lamports(1_000_000_000)
+        .build();
+
+    let result = SyncMetadataBuilder::new()
+        .unwrapped_mint(unwrapped_mint)
+        .wrapped_mint(wrapped_mint)
+        .execute();
+
+    let wrapped_mint_state =
+        PodStateWithExtensions::<PodMint>::unpack(&result.wrapped_mint.account.data).unwrap();
+    let wrapped_metadata = wrapped_mint_state
+        .get_variable_len_extension::<TokenMetadata>()
+        .unwrap();
+
+    if let MintExtension::TokenMetadata {
+        name,
+        symbol,
+        uri,
+        additional_metadata,
+    } = unwrapped_metadata
+    {
+        assert_eq!(wrapped_metadata.name, name);
+        assert_eq!(wrapped_metadata.symbol, symbol);
+        assert_eq!(wrapped_metadata.uri, uri);
+        assert_eq!(wrapped_metadata.additional_metadata, additional_metadata);
+    } else {
+        panic!("destructure failed");
+    }
+}
+
+#[test]
+fn test_success_initialize_metadata_with_additional_fields() {
+    let unwrapped_metadata = MintExtension::TokenMetadata {
+        name: "Unwrapped Token".to_string(),
+        symbol: "UWT".to_string(),
+        uri: "https://unwrapped.dev/meta.json".to_string(),
+        additional_metadata: vec![
+            ("key1".to_string(), "value1".to_string()),
+            ("key2".to_string(), "value2".to_string()),
+        ],
+    };
+    let unwrapped_mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken2022)
+        .with_extension(unwrapped_metadata.clone())
+        .build();
+
+    let wrapped_mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken2022)
+        .mint_key(get_wrapped_mint_address(
+            &unwrapped_mint.key,
+            &spl_token_2022::id(),
+        ))
+        .mint_authority(get_wrapped_mint_authority(&get_wrapped_mint_address(
+            &unwrapped_mint.key,
+            &spl_token_2022::id(),
+        )))
+        .with_extension(MetadataPointerExt)
+        .lamports(1_000_000_000)
+        .build();
+
+    let result = SyncMetadataBuilder::new()
+        .unwrapped_mint(unwrapped_mint)
+        .wrapped_mint(wrapped_mint)
+        .execute();
+
+    let wrapped_mint_state =
+        PodStateWithExtensions::<PodMint>::unpack(&result.wrapped_mint.account.data).unwrap();
+    let wrapped_metadata = wrapped_mint_state
+        .get_variable_len_extension::<TokenMetadata>()
+        .unwrap();
+
+    if let MintExtension::TokenMetadata {
+        name,
+        symbol,
+        uri,
+        additional_metadata,
+    } = unwrapped_metadata
+    {
+        assert_eq!(wrapped_metadata.name, name);
+        assert_eq!(wrapped_metadata.symbol, symbol);
+        assert_eq!(wrapped_metadata.uri, uri);
+        assert_eq!(wrapped_metadata.additional_metadata, additional_metadata);
+    } else {
+        panic!("destructure failed");
+    }
+}
+
+#[test]
+fn test_success_update_metadata() {
+    // Wrapped mint with old metadata that needs to be updated
+    let old_metadata = MintExtension::TokenMetadata {
+        name: "Old Name".to_string(),
+        symbol: "OLD".to_string(),
+        uri: "https://old.uri".to_string(),
+        additional_metadata: vec![],
+    };
+
+    // Unwrapped mint with the new metadata
+    let new_metadata = MintExtension::TokenMetadata {
+        name: "Updated Name".to_string(),
+        symbol: "UPD".to_string(),
+        uri: "https://updated.uri".to_string(),
+        additional_metadata: vec![],
+    };
+
+    let unwrapped_mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken2022)
+        .with_extension(new_metadata.clone())
+        .build();
+
+    let wrapped_mint_address = get_wrapped_mint_address(&unwrapped_mint.key, &spl_token_2022::id());
+    let wrapped_mint_authority = get_wrapped_mint_authority(&wrapped_mint_address);
+    let wrapped_mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken2022)
+        .mint_key(wrapped_mint_address)
+        .mint_authority(wrapped_mint_authority)
+        .with_extension(MetadataPointerExt)
+        .with_extension(old_metadata)
+        .lamports(1_000_000_000)
+        .build();
+
+    let result = SyncMetadataBuilder::new()
+        .unwrapped_mint(unwrapped_mint)
+        .wrapped_mint(wrapped_mint)
+        .execute();
+
+    let wrapped_mint_state =
+        PodStateWithExtensions::<PodMint>::unpack(&result.wrapped_mint.account.data).unwrap();
+    let wrapped_metadata = wrapped_mint_state
+        .get_variable_len_extension::<TokenMetadata>()
+        .unwrap();
+
+    if let MintExtension::TokenMetadata {
+        name,
+        symbol,
+        uri,
+        additional_metadata,
+    } = new_metadata
+    {
+        assert_eq!(wrapped_metadata.name, name);
+        assert_eq!(wrapped_metadata.symbol, symbol);
+        assert_eq!(wrapped_metadata.uri, uri);
+        assert_eq!(wrapped_metadata.additional_metadata, additional_metadata);
+    } else {
+        panic!("destructure failed");
+    }
+}
+
+#[test]
+fn test_success_update_metadata_with_additional_fields() {
+    let old_metadata = MintExtension::TokenMetadata {
+        name: "Old Name".to_string(),
+        symbol: "SYM".to_string(),
+        uri: "uri".to_string(),
+        additional_metadata: vec![
+            ("key1".to_string(), "old_value".to_string()),
+            ("key2".to_string(), "value2".to_string()), // to be removed
+        ],
+    };
+
+    let new_metadata = MintExtension::TokenMetadata {
+        name: "Updated Name".to_string(), // updated
+        symbol: "SYM".to_string(),        // same
+        uri: "uri".to_string(),           // same
+        additional_metadata: vec![
+            ("key1".to_string(), "new_value".to_string()), // updated
+            ("key3".to_string(), "value3".to_string()),    // new
+        ],
+    };
+    let unwrapped_mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken2022)
+        .with_extension(new_metadata.clone())
+        .build();
+
+    let wrapped_mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken2022)
+        .mint_key(get_wrapped_mint_address(
+            &unwrapped_mint.key,
+            &spl_token_2022::id(),
+        ))
+        .with_extension(MetadataPointerExt)
+        .with_extension(old_metadata)
+        .lamports(1_000_000_000)
+        .build();
+
+    let result = SyncMetadataBuilder::new()
+        .unwrapped_mint(unwrapped_mint)
+        .wrapped_mint(wrapped_mint)
+        .execute();
+
+    let wrapped_mint_state =
+        PodStateWithExtensions::<PodMint>::unpack(&result.wrapped_mint.account.data).unwrap();
+    let wrapped_metadata = wrapped_mint_state
+        .get_variable_len_extension::<TokenMetadata>()
+        .unwrap();
+
+    if let MintExtension::TokenMetadata {
+        name,
+        symbol,
+        uri,
+        additional_metadata,
+    } = new_metadata
+    {
+        assert_eq!(wrapped_metadata.name, name);
+        assert_eq!(wrapped_metadata.symbol, symbol);
+        assert_eq!(wrapped_metadata.uri, uri);
+        assert_eq!(wrapped_metadata.additional_metadata, additional_metadata);
+    } else {
+        panic!("destructure failed");
+    }
+}
+
+#[test]
+fn test_fail_unwrapped_mint_has_no_metadata() {
+    let unwrapped_mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken2022)
+        .build(); // No metadata extension
+
+    SyncMetadataBuilder::new()
+        .unwrapped_mint(unwrapped_mint)
+        .check(Check::err(
+            TokenWrapError::UnwrappedMintHasNoMetadata.into(),
+        ))
+        .execute();
+}
+
+#[test]
+fn test_fail_incorrect_token_program() {
+    let mollusk = init_mollusk();
+    let unwrapped_mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken2022)
+        .with_extension(MintExtension::TokenMetadata {
+            name: "N".to_string(),
+            symbol: "S".to_string(),
+            uri: "U".to_string(),
+            additional_metadata: vec![],
+        })
+        .build();
+    let wrapped_mint_address = get_wrapped_mint_address(&unwrapped_mint.key, &spl_token_2022::id());
+    let wrapped_mint_authority = get_wrapped_mint_authority(&wrapped_mint_address);
+    let wrapped_mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken2022)
+        .mint_key(wrapped_mint_address)
+        .build();
+
+    // Pass a fake program account instead of the real Token-2022 program
+    let fake_program = KeyedAccount {
+        key: Pubkey::new_unique(),
+        account: create_program_account_loader_v3(&Pubkey::new_unique()),
+    };
+
+    let instruction = Instruction {
+        program_id: id(),
+        accounts: vec![
+            AccountMeta::new(wrapped_mint.key, false),
+            AccountMeta::new_readonly(wrapped_mint_authority, false),
+            AccountMeta::new_readonly(unwrapped_mint.key, false),
+            AccountMeta::new_readonly(fake_program.key, false),
+        ],
+        data: TokenWrapInstruction::SyncMetadataToToken2022.pack(),
+    };
+
+    let accounts = &[
+        wrapped_mint.pair(),
+        (wrapped_mint_authority, Account::default()),
+        unwrapped_mint.pair(),
+        fake_program.pair(),
+    ];
+
+    mollusk.process_and_validate_instruction(
+        &instruction,
+        accounts,
+        &[Check::err(ProgramError::IncorrectProgramId)],
+    );
+}
+
+// TODO: Remove test when spl-token supported
+#[test]
+fn test_fail_unwrapped_mint_not_token_2022() {
+    let unwrapped_mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken)
+        .build();
+
+    SyncMetadataBuilder::new()
+        .unwrapped_mint(unwrapped_mint)
+        .check(Check::err(ProgramError::IncorrectProgramId))
+        .execute();
+}
+
+#[test]
+fn test_fail_wrapped_mint_not_token_2022() {
+    let unwrapped_mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken2022)
+        .with_extension(MintExtension::TokenMetadata {
+            name: "N".to_string(),
+            symbol: "S".to_string(),
+            uri: "U".to_string(),
+            additional_metadata: vec![],
+        })
+        .build();
+    let wrapped_mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken) // Invalid program
+        .mint_key(get_wrapped_mint_address(
+            &unwrapped_mint.key,
+            &spl_token_2022::id(),
+        ))
+        .build();
+
+    SyncMetadataBuilder::new()
+        .unwrapped_mint(unwrapped_mint)
+        .wrapped_mint(wrapped_mint)
+        .check(Check::err(ProgramError::IncorrectProgramId))
+        .execute();
+}
+
+#[test]
+fn test_fail_wrapped_mint_pda_mismatch() {
+    let wrong_wrapped_mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken2022)
+        .mint_key(Pubkey::new_unique()) // Not the derived PDA
+        .build();
+
+    SyncMetadataBuilder::new()
+        .wrapped_mint(wrong_wrapped_mint)
+        .check(Check::err(TokenWrapError::WrappedMintMismatch.into()))
+        .execute();
+}
+
+#[test]
+fn test_fail_wrapped_mint_authority_pda_mismatch() {
+    SyncMetadataBuilder::new()
+        .wrapped_mint_authority(Pubkey::new_unique()) // Not the derived PDA
+        .check(Check::err(TokenWrapError::MintAuthorityMismatch.into()))
+        .execute();
+}


### PR DESCRIPTION
- Adds `SyncMetadataToToken2022` instruction to sync `TokenMetadata` from an unwrapped Token-2022 mint (later will be adding spl-token) to its wrapped Token-2022 mint. Initializes if missing, otherwise updates only changed fields and removes stale additional_metadata keys.

- `CreateMint` no longer initializes `TokenMetadata`. This is a follow up from https://github.com/solana-program/token-wrap/pull/208#discussion_r2252115863.

- MintCustomizer trait methods simplified further to only what is needed.