### PR TITLE
Sync metadata from spl-token to token-2022

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,9 +65,9 @@ dependencies = [
 
 [[package]]
 name = "agave-banking-stage-ingress-types"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c422e4a2aee520d322cc1e8f31d18f6f5ddf963f3bafdfdc55a761d53e1487a5"
+checksum = "8fb8506a1d6144d73476017b38b86894499ac6e62bfa074bef4944b1c0d4385d"
 dependencies = [
  "crossbeam-channel",
  "solana-perf",
@@ -75,9 +75,9 @@ dependencies = [
 
 [[package]]
 name = "agave-feature-set"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "305be18924e302fbc082a145f9c747fabedfaf136dbcb3820134db2d9855a44b"
+checksum = "e35cc5b8887b993ba4975a23b6e098ee10db50e8e23ee3a9523035b7ca35b53b"
 dependencies = [
  "ahash 0.8.12",
  "solana-epoch-schedule",
@@ -89,23 +89,36 @@ dependencies = [
 
 [[package]]
 name = "agave-geyser-plugin-interface"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6893217f1d6d84bdda9cdd3616795ee2c7a0d801f4816ce9f6379dc0734b919"
+checksum = "d1d86d04e054b285bbcba500237ed31fe2e12d97678814cb91647d0e1b810e0c"
 dependencies = [
  "log",
  "solana-clock",
  "solana-signature",
  "solana-transaction",
  "solana-transaction-status",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
+]
+
+[[package]]
+name = "agave-io-uring"
+version = "2.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9baa3925045a36b33bc9372857ac30706e3578f4e6258e811c51b897fd18f44f"
+dependencies = [
+ "io-uring",
+ "libc",
+ "log",
+ "slab",
+ "smallvec",
 ]
 
 [[package]]
 name = "agave-precompiles"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae36b72ead0da029d1dab286a094bb330702a037d121043183343a60c429fd69"
+checksum = "b3ed7e34efadfb4c7c18c12e8594ce01d8ea85a09cbad0c180e316f41e83e064"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -125,9 +138,9 @@ dependencies = [
 
 [[package]]
 name = "agave-reserved-account-keys"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a6adf0495bf92935e022ec0e0caf533ad5d7f47c11145f15e07c276649980a"
+checksum = "685cb445fe51b7b8a914d1b7dd5a0ea0b106fb8ea9454e84c4cd726a5d87c571"
 dependencies = [
  "agave-feature-set",
  "solana-pubkey",
@@ -136,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "agave-transaction-view"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0c7554cab73eb5391b08892e88a8d64d6ad9eb5f1b6eb4eab72ba9ac1a6fad3"
+checksum = "f03b445b2c9c4f6438d977f996780806339ae9bbc4bcc9af8bbd9ddc1148778a"
 dependencies = [
  "solana-hash",
  "solana-message",
@@ -152,16 +165,16 @@ dependencies = [
 
 [[package]]
 name = "agave-xdp"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "127129f0d18f84b2e9ecb51c98c76735facc32ef79908a179b3ffb990365f489"
+checksum = "b580f01d9493f381ad7dc28a57717359152fd0e61428df5a635dbcaa7c6c69a6"
 dependencies = [
  "aya",
  "caps",
  "crossbeam-channel",
  "libc",
  "log",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -244,9 +257,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
 name = "aquamarine"
@@ -461,9 +474,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.25"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40f6024f3f856663b45fd0c9b6f2024034a702f453549449e0d84a305900dad4"
+checksum = "ddb939d66e4ae03cee6091612804ba446b12878410cfa17f785f4dd67d4014e8"
 dependencies = [
  "brotli",
  "flate2",
@@ -475,11 +488,11 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "3.4.0"
+version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
+checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
 dependencies = [
- "event-listener 5.4.0",
+ "event-listener 5.4.1",
  "event-listener-strategy",
  "pin-project-lite",
 ]
@@ -613,7 +626,7 @@ checksum = "c51b96c5a8ed8705b40d655273bc4212cbbf38d4e3be2788f36306f154523ec7"
 dependencies = [
  "bytes",
  "core-error",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
  "log",
  "object",
  "thiserror 1.0.69",
@@ -683,20 +696,18 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.69.5"
+version = "0.72.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+checksum = "4f72209734318d0b619a5e0f5129918b848c416e122a3c4ce054e03cb87b726f"
 dependencies = [
  "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
- "lazy_static",
- "lazycell",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 1.1.0",
+ "rustc-hash 2.1.1",
  "shlex",
  "syn 2.0.104",
 ]
@@ -948,9 +959,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.27"
+version = "1.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
+checksum = "2352e5597e9c544d5e6d9c95190d5d27738ade584fa8db0a16e130e5c2b5296e"
 dependencies = [
  "jobserver",
  "libc",
@@ -1249,9 +1260,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if 1.0.1",
 ]
@@ -1292,9 +1303,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1466,9 +1477,9 @@ dependencies = [
 
 [[package]]
 name = "derive-where"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "510c292c8cf384b1a340b816a9a6cf2599eb8f566a44949024af88418000c50b"
+checksum = "ef941ded77d15ca19b40374869ac6000af1c9f2a4c0f3d4c70926287e6364a8f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1620,9 +1631,9 @@ checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "eager"
@@ -1784,9 +1795,9 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-listener"
-version = "5.4.0"
+version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -1799,7 +1810,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener 5.4.0",
+ "event-listener 5.4.1",
  "pin-project-lite",
 ]
 
@@ -1819,7 +1830,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27cea6e7f512d43b098939ff4d5a5d6fe3db07971e1d05176fe26c642d33f5b8"
 dependencies = [
  "getrandom 0.3.3",
- "rand 0.9.1",
+ "rand 0.9.2",
  "siphasher 1.0.1",
  "wide",
 ]
@@ -2122,9 +2133,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "globset"
@@ -2180,9 +2191,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
 dependencies = [
  "bytes",
  "fnv",
@@ -2190,10 +2201,10 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "slab",
  "tokio",
- "tokio-util 0.7.15",
+ "tokio-util 0.7.16",
  "tracing",
 ]
 
@@ -2232,9 +2243,9 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -2494,12 +2505,12 @@ dependencies = [
  "http 1.3.1",
  "hyper 1.6.0",
  "hyper-util",
- "rustls 0.23.28",
+ "rustls 0.23.31",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.2",
  "tower-service",
- "webpki-roots 1.0.1",
+ "webpki-roots 1.0.2",
 ]
 
 [[package]]
@@ -2529,9 +2540,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
+checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2545,7 +2556,7 @@ dependencies = [
  "libc",
  "percent-encoding 2.3.1",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tokio",
  "tower-service",
  "tracing",
@@ -2753,12 +2764,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
  "rayon",
  "serde",
 ]
@@ -2796,9 +2807,9 @@ dependencies = [
 
 [[package]]
 name = "io-uring"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
 dependencies = [
  "bitflags 2.9.1",
  "cfg-if 1.0.1",
@@ -2835,6 +2846,15 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -3035,7 +3055,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a35523c6dfa972e1fd19132ef647eff4360a6546c6271807e1327ca6e8797f96"
 dependencies = [
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -3045,16 +3065,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libloading"
@@ -3074,20 +3088,20 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
-version = "0.1.3"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
- "redox_syscall 0.5.13",
+ "redox_syscall 0.5.17",
 ]
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.17.1+9.9.3"
+version = "0.17.3+10.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b7869a512ae9982f4d46ba482c2a304f1efd80c6412a3d4bf57bb79a619679f"
+checksum = "cef2a00ee60fe526157c9023edab23943fae1ce2ab6f4abb2a807c1746835de9"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -3265,9 +3279,9 @@ dependencies = [
 
 [[package]]
 name = "memmap2"
-version = "0.9.5"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
+checksum = "483758ad303d734cec05e5c12b41d7e93e6a6390c5e9dae6bdeb7c1259012d28"
 dependencies = [
  "libc",
 ]
@@ -3444,13 +3458,16 @@ dependencies = [
 
 [[package]]
 name = "mollusk-svm-programs-token"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7b83ea06294d62f3db6cd783d6fcb3bb9c370dff3128b45eac2cb2145c60150"
+checksum = "3efcb4cb61dbf93457a233025a403ba320b831f2c15da9e9a337c38e951eafa7"
 dependencies = [
  "mollusk-svm",
  "solana-account",
  "solana-pubkey",
+ "solana-rent",
+ "spl-associated-token-account",
+ "spl-token",
 ]
 
 [[package]]
@@ -3464,6 +3481,21 @@ dependencies = [
  "solana-program-error",
  "solana-pubkey",
  "solana-rent",
+]
+
+[[package]]
+name = "mpl-token-metadata"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "989e6a3000e761d3b2d685662a3a9ee99826f9369fb033bd1bc7011b1cf02ed9"
+dependencies = [
+ "borsh 0.10.4",
+ "num-derive 0.3.3",
+ "num-traits",
+ "serde",
+ "serde_with",
+ "solana-program",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3594,6 +3626,17 @@ checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "num-derive"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
@@ -3689,8 +3732,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "crc32fast",
- "hashbrown 0.15.4",
- "indexmap 2.9.0",
+ "hashbrown 0.15.5",
+ "indexmap 2.10.0",
  "memchr",
 ]
 
@@ -3749,9 +3792,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-src"
-version = "300.5.0+3.5.0"
+version = "300.5.2+3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ce546f549326b0e6052b649198487d91320875da901e7bd11a06d1ee3f9c2f"
+checksum = "d270b79e2926f5150189d475bc7e9d2c69f9c4697b185fa917d5a32b792d21b4"
 dependencies = [
  "cc",
 ]
@@ -3843,7 +3886,7 @@ checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if 1.0.1",
  "libc",
- "redox_syscall 0.5.13",
+ "redox_syscall 0.5.17",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -3909,7 +3952,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
 dependencies = [
  "memchr",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "ucd-trie",
 ]
 
@@ -3953,7 +3996,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
 ]
 
 [[package]]
@@ -4156,9 +4199,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "d61789d7719defeb74ea5fe81f2fdfdbd28a803847077cecce2ff14e1472f6f1"
 dependencies = [
  "unicode-ident",
 ]
@@ -4273,9 +4316,9 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.1",
- "rustls 0.23.28",
+ "rustls 0.23.31",
  "socket2 0.5.10",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tokio",
  "tracing",
  "web-time",
@@ -4291,14 +4334,14 @@ dependencies = [
  "fastbloom",
  "getrandom 0.3.3",
  "lru-slab",
- "rand 0.9.1",
+ "rand 0.9.2",
  "ring",
  "rustc-hash 2.1.1",
- "rustls 0.23.28",
+ "rustls 0.23.31",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "slab",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tinyvec",
  "tracing",
  "web-time",
@@ -4359,9 +4402,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -4482,9 +4525,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.13"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags 2.9.1",
 ]
@@ -4606,9 +4649,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.20"
+version = "0.12.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabf4c97d9130e2bf606614eb937e86edac8292eaa6f422f995d7e8de1eb1813"
+checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
 dependencies = [
  "async-compression",
  "base64 0.22.1",
@@ -4627,7 +4670,7 @@ dependencies = [
  "percent-encoding 2.3.1",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.28",
+ "rustls 0.23.31",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -4635,7 +4678,7 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-rustls 0.26.2",
- "tokio-util 0.7.15",
+ "tokio-util 0.7.16",
  "tower 0.5.2",
  "tower-http",
  "tower-service",
@@ -4643,7 +4686,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.1",
+ "webpki-roots 1.0.2",
 ]
 
 [[package]]
@@ -4655,7 +4698,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "http 1.3.1",
- "reqwest 0.12.20",
+ "reqwest 0.12.22",
  "serde",
  "thiserror 1.0.69",
  "tower-service",
@@ -4717,9 +4760,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
@@ -4766,15 +4809,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
  "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4791,14 +4834,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.28"
+version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
+checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.3",
+ "rustls-webpki 0.103.4",
  "subtle",
  "zeroize",
 ]
@@ -4812,7 +4855,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.2.0",
+ "security-framework 3.3.0",
 ]
 
 [[package]]
@@ -4845,11 +4888,11 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.28",
+ "rustls 0.23.31",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.3",
- "security-framework 3.2.0",
+ "rustls-webpki 0.103.4",
+ "security-framework 3.3.0",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
  "windows-sys 0.59.0",
@@ -4873,9 +4916,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.3"
+version = "0.103.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4884,9 +4927,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -4944,9 +4987,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1375ba8ef45a6f15d83fa8748f1079428295d403d6ea991d09ab100155fbc06d"
+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -4972,9 +5015,9 @@ dependencies = [
 
 [[package]]
 name = "sdd"
-version = "3.0.8"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "584e070911c7017da6cb2eb0788d09f43d789029b5877d3e5ecc8acf86ceee21"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "security-framework"
@@ -4991,9 +5034,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
+checksum = "80fb1d92c5028aa318b4b8bd7302a5bfcf48be96a37fc6fc790f806b0004ee0c"
 dependencies = [
  "bitflags 2.9.1",
  "core-foundation 0.10.1",
@@ -5099,9 +5142,9 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "schemars 0.9.0",
- "schemars 1.0.3",
+ "schemars 1.0.4",
  "serde",
  "serde_derive",
  "serde_json",
@@ -5127,7 +5170,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "itoa",
  "ryu",
  "serde",
@@ -5250,9 +5293,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.5"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
@@ -5293,9 +5336,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
@@ -5375,9 +5418,9 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee858af4ca998a3d220a764a5b8f542a5ee6b6dc0e4051f8317f297855d7fada"
+checksum = "a5963fbe3e1099613c270fd5ebc0ff5c6e88a2bea2505b6e348daa0466282cd6"
 dependencies = [
  "Inflector",
  "base64 0.22.1",
@@ -5412,15 +5455,15 @@ dependencies = [
  "spl-token-2022 8.0.1",
  "spl-token-group-interface",
  "spl-token-metadata-interface",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "zstd",
 ]
 
 [[package]]
 name = "solana-account-decoder-client-types"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eec60c5d15cac5256ef566193b3a5a56cae9fa35572dc27708946e0a504e843"
+checksum = "59f2101f4cc33e3fbfc8d1d23ea35d8532d6f1fa6a7c7081742e886f98f33126"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -5447,10 +5490,11 @@ dependencies = [
 
 [[package]]
 name = "solana-accounts-db"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80ff8576feab1a1933e5d17fa719a992d9fd8bff8161c7ddd1d87046e3318b83"
+checksum = "0c1896bbe7e8d2cba017f4b44bbb535b8ed55a4645c5b97a7d2ded9564e8e9ac"
 dependencies = [
+ "agave-io-uring",
  "ahash 0.8.12",
  "bincode",
  "blake3",
@@ -5460,11 +5504,12 @@ dependencies = [
  "bzip2",
  "crossbeam-channel",
  "dashmap",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
+ "io-uring",
  "itertools 0.12.1",
  "log",
  "lz4",
- "memmap2 0.9.5",
+ "memmap2 0.9.7",
  "modular-bitfield",
  "num_cpus",
  "num_enum",
@@ -5473,6 +5518,7 @@ dependencies = [
  "seqlock",
  "serde",
  "serde_derive",
+ "slab",
  "smallvec",
  "solana-account",
  "solana-address-lookup-table-interface",
@@ -5504,7 +5550,7 @@ dependencies = [
  "static_assertions",
  "tar",
  "tempfile",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -5535,9 +5581,9 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-client"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29aba14bedce537afc3829297be4f76529a5c4e4e44a97945186ffbdea416e3f"
+checksum = "d063609854a704eda59635fbd28c1326957b02ac7f1a376a4ba05f5aee629c12"
 dependencies = [
  "borsh 1.5.7",
  "futures 0.3.31",
@@ -5556,16 +5602,16 @@ dependencies = [
  "solana-transaction-context",
  "solana-transaction-error",
  "tarpc",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tokio",
  "tokio-serde",
 ]
 
 [[package]]
 name = "solana-banks-interface"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94927be3a1d6c7acd56ecdf376c8497274a65f1bacbab62344dcda61994025e"
+checksum = "348502aed4ad5b30e0d27007c9331d6792aa166ff3a34e7049c513fc4c9063a6"
 dependencies = [
  "serde",
  "serde_derive",
@@ -5584,9 +5630,9 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-server"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39bd2d1c62419f2463e34a3698ae95ab28dc455302f04b580079d8abec1aa03"
+checksum = "78d2b654b09b00d2a52df5abdf82a0b4b46703e6dabb87fe99a959859043c514"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -5648,9 +5694,9 @@ dependencies = [
 
 [[package]]
 name = "solana-bloom"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b742a3dd4135722e1343ee6edfad4ebe4df91c8b638a1c736fafc8b4a3d09049"
+checksum = "a4c3cb0f81bb8f57e59ed2375efe05e1922fd246831dbc677973180d1b744fe9"
 dependencies = [
  "bv",
  "fnv",
@@ -5673,7 +5719,7 @@ dependencies = [
  "ark-serialize",
  "bytemuck",
  "solana-define-syscall",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -5688,9 +5734,9 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f64ed51006b8cd4e65b0750b789c15501935c423bdd643572d31ad75e692f4b"
+checksum = "c3683aa9cca66ebf45f700336127c7375c5117ecec9060bf1baf5209601c5331"
 dependencies = [
  "bincode",
  "libsecp256k1",
@@ -5730,19 +5776,19 @@ dependencies = [
  "solana-timings",
  "solana-transaction-context",
  "solana-type-overrides",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
 name = "solana-bucket-map"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "393442b233b4ce3f1ba3ec7f6c74678328da39190354fe96138664da1036cae0"
+checksum = "d3e741372956b0c16e7afc6e9417c1780240f6f9a3651c8ebea87c85095e393f"
 dependencies = [
  "bv",
  "bytemuck",
  "bytemuck_derive",
- "memmap2 0.9.5",
+ "memmap2 0.9.7",
  "modular-bitfield",
  "num_enum",
  "rand 0.8.5",
@@ -5754,9 +5800,9 @@ dependencies = [
 
 [[package]]
 name = "solana-builtins"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5578ee7b2c17e0c760e79bf5e732fe9ed3406927418192262ee68c843862d26"
+checksum = "16594c9f661decb9e562ab459f7ddf587654159dd757bb17a08814534809c42d"
 dependencies = [
  "agave-feature-set",
  "solana-bpf-loader-program",
@@ -5775,9 +5821,9 @@ dependencies = [
 
 [[package]]
 name = "solana-builtins-default-costs"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497dbe0268b0a18b0783c0b4fde9ace966905b8772ceafe0bf78c690ea7ae17a"
+checksum = "b75c73a28594da1aac17ce9641830a48c1bc7dd7156db16ba939eb6811b4ee1b"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.12",
@@ -5794,9 +5840,9 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd2c2761fb93b264edc3973b934e1c716a8a15b87b7b7bdf4bc28f541d2bd15a"
+checksum = "5292601cbb663699717d89171cc70d49c4305f8b9c8b0ab1928eac1037f39496"
 dependencies = [
  "chrono",
  "clap 2.34.0",
@@ -5815,7 +5861,7 @@ dependencies = [
  "solana-seed-phrase",
  "solana-signature",
  "solana-signer",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tiny-bip39",
  "uriparse",
  "url 2.5.4",
@@ -5823,9 +5869,9 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-v3-utils"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e3b8152977e2eb53dcdaf42d48069086b51cc3fd2902d5af4a5bc4e791f655"
+checksum = "b96a1a0ac320023918e86fdba761ad3e316a7a60b5025a99e43e5ad151a1be8a"
 dependencies = [
  "chrono",
  "clap 3.2.25",
@@ -5846,7 +5892,7 @@ dependencies = [
  "solana-signature",
  "solana-signer",
  "solana-zk-token-sdk",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tiny-bip39",
  "uriparse",
  "url 2.5.4",
@@ -5854,9 +5900,9 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "489867877d20887535fb921f0b8011870b1092df720b26dc32be28a8bb721745"
+checksum = "7d926afc6b19af6f662d4a235ff63fd2836406d29a7c731fc91b6226bb5c82ba"
 dependencies = [
  "dirs-next",
  "serde",
@@ -5869,9 +5915,9 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-output"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa04701a8309da9456198b3386159f71bd71da32ed7efc5c455f3f0914815af"
+checksum = "1bb13e1f3b280a72b29f2b771654e5a8cb22d438850e09f2045a015338fd4309"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
@@ -5912,16 +5958,16 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0996196c72ea12c9e2ae179c000d4cfc626697445058fea2951d5e8b5b054772"
+checksum = "2c4a1e134e7f683fca78ff3912f1590858b51f6a64aad417d30baca8926ed2fd"
 dependencies = [
  "async-trait",
  "bincode",
  "dashmap",
  "futures 0.3.31",
  "futures-util",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "indicatif",
  "log",
  "quinn",
@@ -5952,7 +5998,7 @@ dependencies = [
  "solana-transaction",
  "solana-transaction-error",
  "solana-udp-client",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tokio",
 ]
 
@@ -6013,9 +6059,9 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956fab24ae74baa5b1f611b988365dc0b699977329ef9a3dec30d259e4236804"
+checksum = "11ca5c1ad02e159d1c1d7c79e698a4d3399f22a6a43943032a478b6adc6b359f"
 dependencies = [
  "solana-fee-structure",
  "solana-program-runtime",
@@ -6023,9 +6069,9 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-instruction"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7015d5f7ca1350b27d32cfb79205d92f3c2cdc2d1d7169683110dc59a36b402"
+checksum = "08018e73a6c7e9948cbcb7e7528bd6ae72fc5733344d11038663a3aa7e8d1aeb"
 dependencies = [
  "agave-feature-set",
  "log",
@@ -6039,7 +6085,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-svm-transaction",
  "solana-transaction-error",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -6055,9 +6101,9 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b24dbcc51c760ceb16c0447ef57ca81f38c408c0015f58017b7b3644a34949a3"
+checksum = "721657cd1f8022e36338ca93f01843f39404a4223c37b7c025116fff172d7a4f"
 dependencies = [
  "solana-program-runtime",
 ]
@@ -6077,15 +6123,15 @@ dependencies = [
 
 [[package]]
 name = "solana-connection-cache"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c12756666d382704ebdb9e49f2f37f3d1262866df60cbd8799dd2877b3195528"
+checksum = "be7fcabde8fdaa5a0e6fbbd0ed4cd07e5754e7d187b69be663811c236b891961"
 dependencies = [
  "async-trait",
  "bincode",
  "crossbeam-channel",
  "futures-util",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "log",
  "rand 0.8.5",
  "rayon",
@@ -6094,15 +6140,15 @@ dependencies = [
  "solana-metrics",
  "solana-time-utils",
  "solana-transaction-error",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tokio",
 ]
 
 [[package]]
 name = "solana-core"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98097e38038ef7ff05ccd46084f1b8f4e498d69802d93354f9ebb98977344ab9"
+checksum = "e788da7969811e5b1fd2a53432a84d53e5238ffe62e0b44949feae1b18a7566b"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "agave-feature-set",
@@ -6136,7 +6182,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rayon",
  "rolling-file",
- "rustls 0.23.28",
+ "rustls 0.23.31",
  "serde",
  "serde_bytes",
  "serde_derive",
@@ -6225,18 +6271,18 @@ dependencies = [
  "sys-info",
  "sysctl",
  "tempfile",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tikv-jemallocator",
  "tokio",
- "tokio-util 0.7.15",
+ "tokio-util 0.7.16",
  "trees",
 ]
 
 [[package]]
 name = "solana-cost-model"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66c6cfb9e7de54093d3616a57cf681e2ef2677688023c2928aaedd88add234f"
+checksum = "4eedb024203ce2ef73bf90f10cc6249402b41a1d9421f01a1d8272defe60b33d"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.12",
@@ -6276,16 +6322,16 @@ dependencies = [
 
 [[package]]
 name = "solana-curve25519"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b575bfa3a3775e4201cd5179d4d390a056b8dc691a3df8ac754e8d7e629454"
+checksum = "b162f50499b391b785d57b2f2c73e3b9754d88fd4894bef444960b00bda8dcca"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
  "curve25519-dalek 4.1.3",
  "solana-define-syscall",
  "subtle",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -6331,9 +6377,9 @@ dependencies = [
 
 [[package]]
 name = "solana-entry"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed9a49fe5b880520a643132df77f1506401b6befbc8c38cb783751c8befed89"
+checksum = "eaea0ea9cc773e536125aaf1f7a899478e1a983dd3922f41e080bb4143997ba4"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -6421,14 +6467,14 @@ dependencies = [
  "solana-pubkey",
  "solana-sdk-ids",
  "solana-system-interface",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
 name = "solana-faucet"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeb458bd9eaef3c8b944f061f52997890c4fa162e10401b0cf6b3111e2f6ebe3"
+checksum = "14296b9212f824425cccd30eadcdd5aaa28a5fe99ef7d1cf10f0a3218376e09c"
 dependencies = [
  "bincode",
  "clap 2.34.0",
@@ -6453,7 +6499,7 @@ dependencies = [
  "solana-transaction",
  "solana-version",
  "spl-memo",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tokio",
 ]
 
@@ -6492,9 +6538,9 @@ dependencies = [
 
 [[package]]
 name = "solana-fee"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "893a01826c2feff2d6fa6972efbf64edb3025704966e17ae3d02b95f80b0ddcd"
+checksum = "84f835d9020fc0129593cb5e76daa8f8a4edaf916fc2ae0148a23fe56c220337"
 dependencies = [
  "agave-feature-set",
  "solana-fee-structure",
@@ -6556,9 +6602,9 @@ dependencies = [
 
 [[package]]
 name = "solana-geyser-plugin-manager"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4685682650cd3bcd20d373720e702050f896b028671a03bfca97d38267ccc6e4"
+checksum = "a02a5c514606d0b5683472695f77049ef240f41979a6e0e2976abfe3d240bec6"
 dependencies = [
  "agave-geyser-plugin-interface",
  "bs58",
@@ -6581,15 +6627,15 @@ dependencies = [
  "solana-signature",
  "solana-transaction",
  "solana-transaction-status",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tokio",
 ]
 
 [[package]]
 name = "solana-gossip"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c9d842c5dfff756924f0da26e489a3896e5413cc4a62fe910e5e09891070b0d"
+checksum = "e4207b0b7fcc8d9654fe18fae756facba440574055776aae6df6e0f51dc1586c"
 dependencies = [
  "agave-feature-set",
  "arrayvec",
@@ -6599,7 +6645,7 @@ dependencies = [
  "clap 2.34.0",
  "crossbeam-channel",
  "flate2",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "itertools 0.12.1",
  "log",
  "lru",
@@ -6648,7 +6694,7 @@ dependencies = [
  "solana-vote",
  "solana-vote-program",
  "static_assertions",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -6770,9 +6816,9 @@ dependencies = [
 
 [[package]]
 name = "solana-lattice-hash"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5ee227f72ca6443a4c5e12097577771fb187e4fce91b03abcf05fd42a5c2ca0"
+checksum = "f8f3b668f433cd8716b2db7f58682abc8f7cc876dbe86f27620abb91fa13e4e5"
 dependencies = [
  "base64 0.22.1",
  "blake3",
@@ -6782,9 +6828,9 @@ dependencies = [
 
 [[package]]
 name = "solana-ledger"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda868b6039a907d3d0c9be7dfdc99311495094370b84a610d75bd8791189d1f"
+checksum = "2b489ff3e611c19ed2f527dcdb7e87643df158d74062ab093158dcb3ecffa0a9"
 dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
@@ -6871,7 +6917,7 @@ dependencies = [
  "strum_macros",
  "tar",
  "tempfile",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tokio",
  "tokio-stream",
  "trees",
@@ -6937,9 +6983,9 @@ dependencies = [
 
 [[package]]
 name = "solana-loader-v4-program"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef686d9ddf3a9cccbf8a10d7618b2038a375bb65fb93e8969625e1c2b4bc0c29"
+checksum = "cfbb2ff7b431e9beb683287d5d0c1fedce60c92ac78ccc0fe86e5e363949f044"
 dependencies = [
  "log",
  "qualifier_attr",
@@ -6962,9 +7008,9 @@ dependencies = [
 
 [[package]]
 name = "solana-log-collector"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec7b7fd84dc54f43c26417460cb1b420cf7abf193395155a7ba94ceb105e3568"
+checksum = "8f3560dcb42a0317610a0e226553ef7cad28063cf4082e94bd51b28f449eb79a"
 dependencies = [
  "log",
 ]
@@ -6984,15 +7030,15 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b595ca49ec02c6f3f31c6ff7788186b982ad211600c8d885baf389171af8a52"
+checksum = "4e0e02388fa871b8b42c59ff5f7123370c47a5f389f8e773b4c5402c20ec7e04"
 
 [[package]]
 name = "solana-merkle-tree"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32dba431433a1c63bc6771e8abab8eed44f1c34d1b27810b19afee6fdbe63a9e"
+checksum = "e4b1c019497aa4936234d33d857d8984986fc7134e99a5d1379b997d6552cf04"
 dependencies = [
  "fast-math",
  "solana-hash",
@@ -7024,18 +7070,18 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f01c243a2c15e66f6db2c8b11b92c27bbf737b28fff0b39952a294e4befb8c46"
+checksum = "e1f79991e14c635e76ec1d61061305e4e0e6649e213bff2e1b92c59a789bc652"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
  "log",
- "reqwest 0.12.20",
+ "reqwest 0.12.22",
  "solana-cluster-type",
  "solana-sha256-hasher",
  "solana-time-utils",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -7055,9 +7101,9 @@ checksum = "307fb2f78060995979e9b4f68f833623565ed4e55d3725f100454ce78a99a1a3"
 
 [[package]]
 name = "solana-net-utils"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d1c67baf3ee4a1adb5d57f1d68f05fa0d1b261feabe3bdcf51ce9b6a9c67c56"
+checksum = "49f0d5d50fa415f82d18f2b610b7d6d1e747ebe4d2955e977d007e16f3af8d77"
 dependencies = [
  "anyhow",
  "bincode",
@@ -7137,9 +7183,9 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce580238dc07ab2c38555c9dc0e6b02ec44734bf28bac7ab7d70bd4f821b2614"
+checksum = "bee5e3e876ebce18775e8264b4673f45c2b5990e726a45a7f0cd9f3bd6cb1403"
 dependencies = [
  "ahash 0.8.12",
  "bincode",
@@ -7169,9 +7215,9 @@ dependencies = [
 
 [[package]]
 name = "solana-poh"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de6cbbfde6639045dd977fc472e3f87467c8a809e843d45194b3c335522ae6cb"
+checksum = "e4f714f581837f194802c99e344ffe206a7fd9c5d9288534395da27db014c688"
 dependencies = [
  "core_affinity",
  "crossbeam-channel",
@@ -7188,7 +7234,7 @@ dependencies = [
  "solana-runtime",
  "solana-time-utils",
  "solana-transaction",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -7203,14 +7249,14 @@ dependencies = [
 
 [[package]]
 name = "solana-poseidon"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a44faa88ef8d2b0bbc50d6e43fc24adcaf76a716e3d77af23d670e5f9adc36"
+checksum = "a34309a2d552e2ecaa137c54dc5d7169396efb4661d8aa6ad5672918d5861e0a"
 dependencies = [
  "ark-bn254",
  "light-poseidon",
  "solana-define-syscall",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -7253,7 +7299,7 @@ dependencies = [
  "log",
  "memoffset",
  "num-bigint 0.4.6",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "rand 0.8.5",
  "serde",
@@ -7310,7 +7356,7 @@ dependencies = [
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-vote-interface",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "wasm-bindgen",
 ]
 
@@ -7368,9 +7414,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e68cc7ec43ce85bc4074edb0a31019b09f098620dde220bd94ccec5e158b27"
+checksum = "dac7cb2bb398019a3a23b71828c9ba66a6390cd557b402759a5261ec82e4a928"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -7406,14 +7452,14 @@ dependencies = [
  "solana-timings",
  "solana-transaction-context",
  "solana-type-overrides",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
 name = "solana-program-test"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da6fd84f39e3a89572c53f591d0de12065530145f19a34e16b925938a4fec8c"
+checksum = "1ef9934258fdf3201faf6acb221f4c2dad95f7f6d394120139b3bbffb28f7fa2"
 dependencies = [
  "agave-feature-set",
  "assert_matches",
@@ -7468,7 +7514,7 @@ dependencies = [
  "solana-transaction-error",
  "solana-vote-program",
  "spl-generic-token",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tokio",
 ]
 
@@ -7501,9 +7547,9 @@ dependencies = [
 
 [[package]]
 name = "solana-pubsub-client"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790b7f82ba1a94e2b4157b80b96a5aa6e1935884011d42bc2e741fcf2e04719d"
+checksum = "e2b90bcec41efc8ed9e6b765e043e9fb5984b5c3fbf16f4d2c1dc827fd4b35e2"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -7518,7 +7564,7 @@ dependencies = [
  "solana-pubkey",
  "solana-rpc-client-types",
  "solana-signature",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
@@ -7528,9 +7574,9 @@ dependencies = [
 
 [[package]]
 name = "solana-quic-client"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6ebbc200b13f9025959d3d5b449dc21fed85a8e206e93df7d41692623b81fe9"
+checksum = "50f5c70a7b38bf0b672f51a718c4b377adf0ae218d8d576024e7c3ed00e7ee86"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -7539,7 +7585,7 @@ dependencies = [
  "log",
  "quinn",
  "quinn-proto",
- "rustls 0.23.28",
+ "rustls 0.23.31",
  "solana-connection-cache",
  "solana-keypair",
  "solana-measure",
@@ -7552,7 +7598,7 @@ dependencies = [
  "solana-streamer",
  "solana-tls-utils",
  "solana-transaction-error",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tokio",
 ]
 
@@ -7567,24 +7613,24 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9c13901b04461d7e40c49c34b3ba8acc78c268ecdfa069388a1af7689f948eb"
+checksum = "ee3a2eac4ab76fc2e269d5b7e84d6e728b5b2ea30644e61182471bf4e0c4b44d"
 dependencies = [
  "num_cpus",
 ]
 
 [[package]]
 name = "solana-remote-wallet"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4239570d97091162bbd6b9ff1c09c1b77c266a151f73145ede3ab8d7580c054"
+checksum = "8fe4453541415b21c79fae84980d82854f1d6a19c13a09f6eba75aa273a7c1c0"
 dependencies = [
  "console",
  "dialoguer",
  "hidapi",
  "log",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "parking_lot 0.12.4",
  "qstring",
@@ -7594,7 +7640,7 @@ dependencies = [
  "solana-pubkey",
  "solana-signature",
  "solana-signer",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "uriparse",
 ]
 
@@ -7650,9 +7696,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6225300a01267ff4fd8c2d14a1a1c26317578e9e72a86b4eb573eeee8a748b5"
+checksum = "d052c864bb0c93dd2294c01a01f1f51de53f7087c0c8a973791c1da6c97c5cc9"
 dependencies = [
  "agave-feature-set",
  "base64 0.22.1",
@@ -7729,16 +7775,16 @@ dependencies = [
  "spl-token",
  "spl-token-2022 8.0.1",
  "stream-cancel",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tokio",
- "tokio-util 0.7.15",
+ "tokio-util 0.7.16",
 ]
 
 [[package]]
 name = "solana-rpc-client"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d1d20f10a354123122bdbf6ad90997d7615504f3256a6408717fadc8bcd26f9"
+checksum = "40231712d6f1e5833ff1e101954786cbd0b5301098ea42384f7bb3e553085852"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7747,7 +7793,7 @@ dependencies = [
  "futures 0.3.31",
  "indicatif",
  "log",
- "reqwest 0.12.20",
+ "reqwest 0.12.22",
  "reqwest-middleware",
  "semver",
  "serde",
@@ -7776,13 +7822,13 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-api"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "627c1c573afaa2515cb8127766535c3a88e845e3fba264db3e3e7da63ac508fc"
+checksum = "5a1be31922f97505007ccf969828b34e8dc43ce434a17f970b0edea8f0e66777"
 dependencies = [
  "anyhow",
  "jsonrpc-core",
- "reqwest 0.12.20",
+ "reqwest 0.12.22",
  "reqwest-middleware",
  "serde",
  "serde_derive",
@@ -7793,14 +7839,14 @@ dependencies = [
  "solana-signer",
  "solana-transaction-error",
  "solana-transaction-status-client-types",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
 name = "solana-rpc-client-nonce-utils"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65cd21225d3c95f10dccf51516454ff9e1ff788aabd2c799d97f14691eb7224c"
+checksum = "b2bd5b1ccc7fc945a9b0adad091836ee18b7688afd6979889849d5404254a14f"
 dependencies = [
  "solana-account",
  "solana-commitment-config",
@@ -7810,14 +7856,14 @@ dependencies = [
  "solana-pubkey",
  "solana-rpc-client",
  "solana-sdk-ids",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
 name = "solana-rpc-client-types"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046675cd97165f93460535f7ff241c44f90a73d8dabe7edc009505b393ff9248"
+checksum = "6e82a9b71f023a4bd511088f22e3c1f0e226a6e2e94b0656776509f234dd223a"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -7836,14 +7882,14 @@ dependencies = [
  "solana-transaction-status-client-types",
  "solana-version",
  "spl-generic-token",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
 name = "solana-runtime"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "573a11eb4e4ab8e17680e7139c5efb8f033c8e68eb49fc62fc6b21fde48febaf"
+checksum = "f6c416cf6f9a1bff7dca25234406b4c776ea97de18cb89ba4bf987578cd32918"
 dependencies = [
  "agave-feature-set",
  "agave-precompiles",
@@ -7868,10 +7914,10 @@ dependencies = [
  "libc",
  "log",
  "lz4",
- "memmap2 0.9.5",
+ "memmap2 0.9.7",
  "mockall",
  "modular-bitfield",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "num_cpus",
  "num_enum",
@@ -7972,15 +8018,15 @@ dependencies = [
  "symlink",
  "tar",
  "tempfile",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "zstd",
 ]
 
 [[package]]
 name = "solana-runtime-transaction"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6cf481e2b98a86a000018dffd8eb7084e38f8d3c59bbcc38dba3c531ce918d5"
+checksum = "9ace4ea88917f5984c18d177854e002900b4942eaa5d4c4b38ca0df5b58d23ad"
 dependencies = [
  "agave-transaction-view",
  "log",
@@ -7994,7 +8040,7 @@ dependencies = [
  "solana-svm-transaction",
  "solana-transaction",
  "solana-transaction-error",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -8016,7 +8062,7 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "rustc-demangle",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "winapi 0.3.9",
 ]
 
@@ -8063,7 +8109,7 @@ checksum = "baa3120b6cdaa270f39444f5093a90a7b03d296d362878f7a6991d6de3bbe496"
 dependencies = [
  "libsecp256k1",
  "solana-define-syscall",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -8108,9 +8154,9 @@ dependencies = [
 
 [[package]]
 name = "solana-send-transaction-service"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494d5258acfde438226e47e1f93e98ea23997782cd4a7a6dc1ca026caaaa955e"
+checksum = "8d79e8636637fc77c79e0bf615ee238fbc7f20a8be2b7cfbf78e548a12f3685d"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
@@ -8131,7 +8177,7 @@ dependencies = [
  "solana-time-utils",
  "solana-tpu-client-next",
  "tokio",
- "tokio-util 0.7.15",
+ "tokio-util 0.7.16",
 ]
 
 [[package]]
@@ -8278,9 +8324,9 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-program"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d841d4bf2f3f7fed557e132ee3b87276ad6852c875bedb2004257a3285071073"
+checksum = "f5810d9257db488570977cf57a7734f45e829bf00f0a3179fac57f901172064e"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -8307,9 +8353,9 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-bigtable"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8370c43db89d0490e9f79c51afd0e0216409155c46dc6809699184bd173f2e26"
+checksum = "b8f55cf5d011841a8061c2a83be6f4757b3d51b045ac9e45a33a78a9e24ba043"
 dependencies = [
  "agave-reserved-account-keys",
  "backoff",
@@ -8341,7 +8387,7 @@ dependencies = [
  "solana-transaction",
  "solana-transaction-error",
  "solana-transaction-status",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tokio",
  "tonic",
  "zstd",
@@ -8349,9 +8395,9 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98c7eb1f1e678d60fd2d970e925514fdbf595f904351fcf42ad4dc6a1591c89"
+checksum = "590eaf69c41d0bb63809daff5947abadffae68194ef5a6e10c3154b141cab3b5"
 dependencies = [
  "bincode",
  "bs58",
@@ -8374,9 +8420,9 @@ dependencies = [
 
 [[package]]
 name = "solana-streamer"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb37589b70d001ea9be5712322c941ed49e50c5b51b9242ec363213ebcd1ad79"
+checksum = "3f55673d787ef1478fa2939801e8bde7cb4ed38a99ff3d5541c2d159a06904f3"
 dependencies = [
  "async-channel",
  "bytes",
@@ -8386,7 +8432,7 @@ dependencies = [
  "futures-util",
  "governor",
  "histogram",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "itertools 0.12.1",
  "libc",
  "log",
@@ -8396,7 +8442,7 @@ dependencies = [
  "quinn",
  "quinn-proto",
  "rand 0.8.5",
- "rustls 0.23.28",
+ "rustls 0.23.31",
  "smallvec",
  "socket2 0.5.10",
  "solana-keypair",
@@ -8413,17 +8459,17 @@ dependencies = [
  "solana-tls-utils",
  "solana-transaction-error",
  "solana-transaction-metrics-tracker",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tokio",
- "tokio-util 0.7.15",
+ "tokio-util 0.7.16",
  "x509-parser",
 ]
 
 [[package]]
 name = "solana-svm"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ec2aa64eba7d7a353912c3250ccb390a293600d1d802c3e71528d4b292a23e9"
+checksum = "80abd376f5f4bdcfd690accb447a3b8b1cf5b24c0cc345993a2759b234d11a6e"
 dependencies = [
  "ahash 0.8.12",
  "itertools 0.12.1",
@@ -8465,14 +8511,14 @@ dependencies = [
  "solana-transaction-error",
  "solana-type-overrides",
  "spl-generic-token",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
 name = "solana-svm-callback"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfa93939bf68a7fcce87cc055ca10e5022ea413d0ab68347ac9cf4c2bd4279b"
+checksum = "921ca8c29cda72f16b49dff70cd87e87d9058a69804926f459e0b8584d621985"
 dependencies = [
  "solana-account",
  "solana-precompile-error",
@@ -8481,15 +8527,15 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-feature-set"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16c5cf1acee9ce9333f62fea518b641e0454245004def6cb938fd3a182e1526c"
+checksum = "e65361fa1fb2a123319df6d9694c1c5ca20e555cda18eb1f953babf32e4cddd4"
 
 [[package]]
 name = "solana-svm-rent-collector"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384089d0f69adce76898e0ba1efce90b013ce2152f48c69abe8586c04da28efd"
+checksum = "20f1d3196d0c586fa43ab7f80143a248ccc262b9175be2ea5ab637caf2d02ca4"
 dependencies = [
  "solana-account",
  "solana-clock",
@@ -8503,9 +8549,9 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-transaction"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c58c6fc46c17751811e47f2bcdd1351456e45dc738ac600599bfd6469e957e"
+checksum = "6e6f46c247cb7a345e72468ba2bcdf69d464f8fdae7bf6366cd31d6e2d7692d6"
 dependencies = [
  "solana-hash",
  "solana-message",
@@ -8533,9 +8579,9 @@ dependencies = [
 
 [[package]]
 name = "solana-system-program"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e737e67d327b8260306522fde5758a1b09af5e6cd630d589c25e610f74a0c6a8"
+checksum = "42817e69449ea37ddc6556a3086152069ac9330d061f0948e66b7b30ac396903"
 dependencies = [
  "bincode",
  "log",
@@ -8622,9 +8668,9 @@ dependencies = [
 
 [[package]]
 name = "solana-test-validator"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01fe86b8e15fa26b21109a828ec169bdffd7cc2d9dc70199aebdcae55c6ab97e"
+checksum = "aeb11d85e6ebf5b69075cf1dce8e40ab1f9c9e261bcd7a5f5d4edaf278faf2bb"
 dependencies = [
  "agave-feature-set",
  "base64 0.22.1",
@@ -8671,9 +8717,9 @@ dependencies = [
 
 [[package]]
 name = "solana-thin-client"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec856519104a1a627128814613c394298035682ff17f84b43dcfebe7d06b070f"
+checksum = "25571fe8261c632206373ccbf35edf12a476405264a0d0829adf65202c0e1c17"
 dependencies = [
  "bincode",
  "log",
@@ -8706,9 +8752,9 @@ checksum = "6af261afb0e8c39252a04d026e3ea9c405342b08c871a2ad8aa5448e068c784c"
 
 [[package]]
 name = "solana-timings"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda43b3a20f03b5cc0bb235861b53debcf01885de214dd77087c4d349e571bd6"
+checksum = "5d70d69d9f5683bffe3e43590ef62a016c239e3b3466e31b3840e0eb64a808db"
 dependencies = [
  "eager",
  "enum-iterator",
@@ -8717,11 +8763,11 @@ dependencies = [
 
 [[package]]
 name = "solana-tls-utils"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "551324868ad575956030bdebd21f59e3acd4aa479d60cd34a799fb1b08b1bfbe"
+checksum = "cbab408af08c4b0dc103b608f053e8bf7aec9f18a20da79fb98ccf35950ee468"
 dependencies = [
- "rustls 0.23.28",
+ "rustls 0.23.31",
  "solana-keypair",
  "solana-pubkey",
  "solana-signer",
@@ -8730,14 +8776,14 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d4344d21c30da45d114b70ad2080a6cee0905babf1abbd450c92627118cb5a"
+checksum = "5cc8ccdb1b26950de965860e02285361c48563d3b5eef64166fe45b5b9245e1b"
 dependencies = [
  "async-trait",
  "bincode",
  "futures-util",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "indicatif",
  "log",
  "rayon",
@@ -8745,7 +8791,7 @@ dependencies = [
  "solana-clock",
  "solana-commitment-config",
  "solana-connection-cache",
- "solana-epoch-info",
+ "solana-epoch-schedule",
  "solana-measure",
  "solana-message",
  "solana-net-utils",
@@ -8758,21 +8804,21 @@ dependencies = [
  "solana-signer",
  "solana-transaction",
  "solana-transaction-error",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tokio",
 ]
 
 [[package]]
 name = "solana-tpu-client-next"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96679ba3213c8dc08f57f5456d8291399a047a7de84a372fc460f78a3f3d51c8"
+checksum = "192fff4e29eaf02d34f8518a82c0e564a5c555b6dd4c251c1080f2ca02bc761f"
 dependencies = [
  "async-trait",
  "log",
  "lru",
  "quinn",
- "rustls 0.23.28",
+ "rustls 0.23.31",
  "solana-clock",
  "solana-connection-cache",
  "solana-keypair",
@@ -8784,9 +8830,9 @@ dependencies = [
  "solana-time-utils",
  "solana-tls-utils",
  "solana-tpu-client",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tokio",
- "tokio-util 0.7.15",
+ "tokio-util 0.7.16",
 ]
 
 [[package]]
@@ -8816,9 +8862,9 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-context"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48a900e43746e45fb0ae279b89b24bd527c35411e483413a1dd39339cea7177a"
+checksum = "aefd75e49dd990f7fdbe562a539a7b046a839aadf43843845d766a2a6a2adfef"
 dependencies = [
  "bincode",
  "serde",
@@ -8845,9 +8891,9 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-metrics-tracker"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc97b2a99ff9280ecdbd3475c43659a3fb40e04e2fbf2967089cfc96b35b396"
+checksum = "f5ffbcb223e76a4e8389f32d447f9d5d68ce0947ba0a3b7db83141085d68c8f3"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8861,9 +8907,9 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dcfad9fb2dd75f1cddaeb087bb8edb4f8cfd91c8b407789c7bed9c68149a573"
+checksum = "287a86e28777cdc8c0745ff5700a2c3741a2a7a72a347a93815e832adfe39dc5"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
@@ -8900,14 +8946,14 @@ dependencies = [
  "spl-token-2022 8.0.1",
  "spl-token-group-interface",
  "spl-token-metadata-interface",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
 name = "solana-transaction-status-client-types"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae65ed465048492d7e3a413300430e340518da4c924394691d1339d99715282"
+checksum = "9e91068d54435121280c4a2f1c280d8d18381e3ccf54057c4530f40f26c2be1c"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8923,14 +8969,14 @@ dependencies = [
  "solana-transaction",
  "solana-transaction-context",
  "solana-transaction-error",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
 name = "solana-turbine"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "706bad6a02f4607dc5f44f9a8c84c284d5ed87c9fffb47dc75cf7a6eae04e16c"
+checksum = "2ddaae7d21c8c62d3945c30d7e5cce09ba15b6f4f50dc37e7dfb6949b99156c6"
 dependencies = [
  "agave-feature-set",
  "agave-xdp",
@@ -8947,7 +8993,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rayon",
- "rustls 0.23.28",
+ "rustls 0.23.31",
  "solana-clock",
  "solana-cluster-type",
  "solana-entry",
@@ -8975,24 +9021,24 @@ dependencies = [
  "solana-tls-utils",
  "solana-transaction-error",
  "static_assertions",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tokio",
 ]
 
 [[package]]
 name = "solana-type-overrides"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33dcab747a0c14e7eeb8b0f2fbf4f9c6879ee88040cddd4c35cce2d94d751bcb"
+checksum = "4789b860088a5d108c9961de6c24008f6310aaae676445d37d40a75d8b55647b"
 dependencies = [
  "rand 0.8.5",
 ]
 
 [[package]]
 name = "solana-udp-client"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5f306726ddef01de07332fb6a2d42a53fc8e36f8fe42286bc830ffb65c2b368"
+checksum = "e42f000524bb38b5af2e0fba649bc3d10b0e8e0dd833dc11389a91e955cb6c54"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
@@ -9000,15 +9046,15 @@ dependencies = [
  "solana-net-utils",
  "solana-streamer",
  "solana-transaction-error",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tokio",
 ]
 
 [[package]]
 name = "solana-unified-scheduler-logic"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2db997197b0b4d104931fd97d06e677dfddbccce2dd62ad5c9f4da383914053a"
+checksum = "b7919d719f697d6a8cae7c2d4372777f9c717cd08fac5f9023c61d3a6e2a7eb9"
 dependencies = [
  "assert_matches",
  "solana-pubkey",
@@ -9020,9 +9066,9 @@ dependencies = [
 
 [[package]]
 name = "solana-unified-scheduler-pool"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05812f753bed2731d885ed3b0a70e098f704735c8d883ad8fb6a124ce7365347"
+checksum = "36ae9e6e21b3bf585d313f8483192bcf1ffcd55c9e442bebbbd9bccd265f1547"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "aquamarine",
@@ -9061,9 +9107,9 @@ checksum = "7bbf6d7a3c0b28dd5335c52c0e9eae49d0ae489a8f324917faf0ded65a812c1d"
 
 [[package]]
 name = "solana-version"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7733d93e7e7efcdb6452e1b3b90b6793eb1fd431dcda54f40b846342aa158f1f"
+checksum = "b4607a9de98043bcf7db9e5d90b31fefb728c80eec901595b6931d7cdc1558b2"
 dependencies = [
  "agave-feature-set",
  "rand 0.8.5",
@@ -9076,9 +9122,9 @@ dependencies = [
 
 [[package]]
 name = "solana-vote"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759fd547ca1d5b42193f1e32d1c7e006a8191f6615848d9daaa7557ce6a7e7d2"
+checksum = "73033bbc54597353f4acd74fb4e14a529f93331089a7d12c21bf9122c6db3957"
 dependencies = [
  "itertools 0.12.1",
  "log",
@@ -9099,17 +9145,17 @@ dependencies = [
  "solana-svm-transaction",
  "solana-transaction",
  "solana-vote-interface",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
 name = "solana-vote-interface"
-version = "2.2.5"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4f08746f154458f28b98330c0d55cb431e2de64ee4b8efc98dcbe292e0672b"
+checksum = "b80d57478d6599d30acc31cc5ae7f93ec2361a06aefe8ea79bc81739a08af4c3"
 dependencies = [
  "bincode",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "serde",
  "serde_derive",
@@ -9128,14 +9174,14 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a34da4eb6552033affdb85ef68496f8d64c2d227fdcaf6490d1be7f10bf294"
+checksum = "5e5775e5665d04ac576c08c0614b32410dcdc46012ca6ac4910b4bd82ba38a71"
 dependencies = [
  "agave-feature-set",
  "bincode",
  "log",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "serde",
  "serde_derive",
@@ -9156,14 +9202,14 @@ dependencies = [
  "solana-transaction",
  "solana-transaction-context",
  "solana-vote-interface",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
 name = "solana-wen-restart"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f057acefc747185c0f651a5b5b4ad78c6499b0d32fc96000854df1ae3a82f1"
+checksum = "fe67d9b07c1387148e1eb85ba9836cb6e477be18e6b8ff079c3645c013fe447d"
 dependencies = [
  "anyhow",
  "log",
@@ -9189,13 +9235,13 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-elgamal-proof-program"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14546c6594edc0df8b1fecc60873667044193972254b027d026b882444ef38f3"
+checksum = "e9b084cb82e20660b079150ae079cdf1ae71c85f3c95f56daee9a5e73fbfb510"
 dependencies = [
  "agave-feature-set",
  "bytemuck",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "solana-instruction",
  "solana-log-collector",
@@ -9206,9 +9252,9 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-sdk"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fb02d3ce872d534e72e1c6c1439e94d0de5cf9fc9477d4dfd99e106530a11be"
+checksum = "3bb171c0f76c420a7cb6aabbe5fa85a1a009d5bb4009189c43e1a03aff9446d7"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",
@@ -9219,7 +9265,7 @@ dependencies = [
  "itertools 0.12.1",
  "js-sys",
  "merlin",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "rand 0.8.5",
  "serde",
@@ -9235,20 +9281,20 @@ dependencies = [
  "solana-signature",
  "solana-signer",
  "subtle",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "wasm-bindgen",
  "zeroize",
 ]
 
 [[package]]
 name = "solana-zk-token-proof-program"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "209d56deb6d74fa4e8130de2c4abaee9e75b914468841d838c7d033cec312b80"
+checksum = "bc711a3c144df1699239f2c411c9efdccbbd6da27a46723b4ba76de86f278246"
 dependencies = [
  "agave-feature-set",
  "bytemuck",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "solana-instruction",
  "solana-log-collector",
@@ -9259,9 +9305,9 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "2.3.1"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5638b7c71d07ccb65b77eb4f86962194d4a9ced22be69ed8b2a51077af56c80c"
+checksum = "0131dcac71c6d63f781354a2aa6a46c89a56a04b438b725ca811a465b90ad506"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",
@@ -9271,7 +9317,7 @@ dependencies = [
  "curve25519-dalek 4.1.3",
  "itertools 0.12.1",
  "merlin",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "rand 0.8.5",
  "serde",
@@ -9288,7 +9334,7 @@ dependencies = [
  "solana-signature",
  "solana-signer",
  "subtle",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "zeroize",
 ]
 
@@ -9314,13 +9360,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae179d4a26b3c7a20c839898e6aed84cb4477adf108a366c95532f058aea041b"
 dependencies = [
  "borsh 1.5.7",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "solana-program",
  "spl-associated-token-account-client",
  "spl-token",
  "spl-token-2022 8.0.1",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -9358,9 +9404,9 @@ dependencies = [
 
 [[package]]
 name = "spl-discriminator-syn"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f05593b7ca9eac7caca309720f2eafb96355e037e6d373b909a80fe7b69b9"
+checksum = "5d1dbc82ab91422345b6df40a79e2b78c7bce1ebb366da323572dd60b7076b67"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9449,7 +9495,7 @@ dependencies = [
  "borsh 1.5.7",
  "bytemuck",
  "bytemuck_derive",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "solana-decode-error",
  "solana-msg",
@@ -9457,7 +9503,7 @@ dependencies = [
  "solana-program-option",
  "solana-pubkey",
  "solana-zk-sdk",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -9466,13 +9512,13 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdebc8b42553070b75aa5106f071fef2eb798c64a7ec63375da4b1f058688c6"
 dependencies = [
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "solana-decode-error",
  "solana-msg",
  "solana-program-error",
  "spl-program-error-derive",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -9494,7 +9540,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1408e961215688715d5a1063cbdcf982de225c45f99c82b4f7d7e1dd22b998d7"
 dependencies = [
  "bytemuck",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "solana-account-info",
  "solana-decode-error",
@@ -9506,7 +9552,7 @@ dependencies = [
  "spl-pod",
  "spl-program-error",
  "spl-type-length-value",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -9517,7 +9563,7 @@ checksum = "053067c6a82c705004f91dae058b11b4780407e9ccd6799dc9e7d0fab5f242da"
 dependencies = [
  "arrayref",
  "bytemuck",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "num_enum",
  "solana-account-info",
@@ -9534,7 +9580,7 @@ dependencies = [
  "solana-rent",
  "solana-sdk-ids",
  "solana-sysvar",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -9545,7 +9591,7 @@ checksum = "31f0dfbb079eebaee55e793e92ca5f433744f4b71ee04880bfd6beefba5973e5"
 dependencies = [
  "arrayref",
  "bytemuck",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "num_enum",
  "solana-account-info",
@@ -9578,7 +9624,7 @@ dependencies = [
  "spl-token-metadata-interface",
  "spl-transfer-hook-interface",
  "spl-type-length-value",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -9589,7 +9635,7 @@ checksum = "707d8237d17d857246b189d0fb278797dcd7cf6219374547791b231fd35a8cc8"
 dependencies = [
  "arrayref",
  "bytemuck",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "num_enum",
  "solana-account-info",
@@ -9622,7 +9668,7 @@ dependencies = [
  "spl-token-metadata-interface",
  "spl-transfer-hook-interface",
  "spl-type-length-value",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -9654,7 +9700,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-zk-sdk",
  "spl-pod",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -9674,7 +9720,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-zk-sdk",
  "spl-pod",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -9685,7 +9731,7 @@ checksum = "ae5b124840d4aed474cef101d946a798b806b46a509ee4df91021e1ab1cef3ef"
 dependencies = [
  "curve25519-dalek 4.1.3",
  "solana-zk-sdk",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -9695,7 +9741,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5597b4cd76f85ce7cd206045b7dc22da8c25516573d42d267c8d1fd128db5129"
 dependencies = [
  "bytemuck",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "solana-decode-error",
  "solana-instruction",
@@ -9704,7 +9750,7 @@ dependencies = [
  "solana-pubkey",
  "spl-discriminator",
  "spl-pod",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -9714,7 +9760,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "304d6e06f0de0c13a621464b1fd5d4b1bebf60d15ca71a44d3839958e0da16ee"
 dependencies = [
  "borsh 1.5.7",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "solana-borsh",
  "solana-decode-error",
@@ -9725,18 +9771,21 @@ dependencies = [
  "spl-discriminator",
  "spl-pod",
  "spl-type-length-value",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
 name = "spl-token-wrap"
 version = "0.1.0"
 dependencies = [
+ "borsh 0.10.4",
  "bytemuck",
  "mollusk-svm",
  "mollusk-svm-programs-token",
- "num-derive",
+ "mpl-token-metadata",
+ "num-derive 0.4.2",
  "num-traits",
+ "serde_json",
  "solana-account",
  "solana-account-info",
  "solana-cpi",
@@ -9760,7 +9809,7 @@ dependencies = [
  "spl-type-length-value",
  "test-case",
  "test-transfer-hook",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -9811,7 +9860,7 @@ checksum = "a7e905b849b6aba63bde8c4badac944ebb6c8e6e14817029cbe1bc16829133bd"
 dependencies = [
  "arrayref",
  "bytemuck",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "solana-account-info",
  "solana-cpi",
@@ -9825,7 +9874,7 @@ dependencies = [
  "spl-program-error",
  "spl-tlv-account-resolution",
  "spl-type-length-value",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -9835,7 +9884,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d417eb548214fa822d93f84444024b4e57c13ed6719d4dcc68eec24fb481e9f5"
 dependencies = [
  "bytemuck",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "solana-account-info",
  "solana-decode-error",
@@ -9843,7 +9892,7 @@ dependencies = [
  "solana-program-error",
  "spl-discriminator",
  "spl-pod",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -10080,7 +10129,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix 1.0.7",
+ "rustix 1.0.8",
  "windows-sys 0.59.0",
 ]
 
@@ -10168,11 +10217,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "0b0949c3a6c842cbde3f1686d6eea5a010516deb7085f79db747562d4102f41e"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.14",
 ]
 
 [[package]]
@@ -10188,9 +10237,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "cc5b44b4ab9c2fdd0e0512e6bece8388e214c0749f5862b114cc5b7a25daf227"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10323,9 +10372,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-io-timeout"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+checksum = "0bd86198d9ee903fedd2f9a2e72014287c0d9167e4ae43b5853007205dda1b76"
 dependencies = [
  "pin-project-lite",
  "tokio",
@@ -10368,7 +10417,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.28",
+ "rustls 0.23.31",
  "tokio",
 ]
 
@@ -10431,9 +10480,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.15"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes",
  "futures-core",
@@ -10464,7 +10513,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "toml_datetime",
  "winnow",
 ]
@@ -10527,7 +10576,7 @@ dependencies = [
  "rand 0.8.5",
  "slab",
  "tokio",
- "tokio-util 0.7.15",
+ "tokio-util 0.7.16",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -10996,14 +11045,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
 dependencies = [
- "webpki-root-certs 1.0.1",
+ "webpki-root-certs 1.0.2",
 ]
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86138b15b2b7d561bc4469e77027b8dd005a43dc502e9031d1f5afc8ce1f280e"
+checksum = "4e4ffd8df1c57e87c325000a3d6ef93db75279dc3a231125aac571650f22b12a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -11025,9 +11074,9 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8782dd5a41a24eed3a4f40b606249b3e236ca61adf1f25ea4d45c73de122b502"
+checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -11198,7 +11247,7 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.2",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -11249,10 +11298,11 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.2"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -11445,9 +11495,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 dependencies = [
  "memchr",
 ]
@@ -11497,12 +11547,12 @@ dependencies = [
 
 [[package]]
 name = "xattr"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e"
+checksum = "af3a19837351dc82ba89f8a125e22a3c475f05aba604acc023d62b2739ae2909"
 dependencies = [
  "libc",
- "rustix 1.0.7",
+ "rustix 1.0.8",
 ]
 
 [[package]]
@@ -11603,9 +11653,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
 dependencies = [
  "yoke",
  "zerofrom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,12 @@ edition = "2021"
 
 [workspace.dependencies]
 anyhow = "1.0.98"
+borsh = "0.10.4"
 bytemuck = { version = "1.23.2", features = ["derive"] }
 clap = { version = "3.2.25", features = ["derive"] }
 mollusk-svm = "0.4.2"
 mollusk-svm-programs-token = "0.4.1"
+mpl-token-metadata = "5.1.0"
 num-derive = "0.4.2"
 num-traits = "0.2.19"
 serde = "1.0.219"

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -13,8 +13,10 @@ test-sbf = []
 
 [dependencies]
 bytemuck = { workspace = true }
+mpl-token-metadata = { workspace = true, features = ["serde"] }
 num-derive = { workspace = true }
 num-traits = { workspace = true }
+serde_json = { workspace = true }
 solana-account-info = { workspace = true }
 solana-cpi = { workspace = true }
 solana-instruction = { workspace = true }
@@ -38,6 +40,7 @@ thiserror = { workspace = true }
 spl-token-2022 = { workspace = true }
 
 [dev-dependencies]
+borsh = { workspace = true }
 mollusk-svm = { workspace = true }
 mollusk-svm-programs-token = { workspace = true }
 solana-account = { workspace = true }

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -45,6 +45,11 @@ pub enum TokenWrapError {
     /// Unwrapped mint does not have the `TokenMetadata` extension
     #[error("Unwrapped mint does not have the TokenMetadata extension")]
     UnwrappedMintHasNoMetadata,
+
+    // 10
+    /// `Metaplex` metadata account address does not match expected PDA
+    #[error("Metaplex metadata account address does not match expected PDA")]
+    MetaplexMetadataMismatch,
 }
 
 impl From<TokenWrapError> for ProgramError {
@@ -77,6 +82,7 @@ impl ToStr for TokenWrapError {
             TokenWrapError::EscrowMismatch => "Error: EscrowMismatch",
             TokenWrapError::EscrowInGoodState => "Error: EscrowInGoodState",
             TokenWrapError::UnwrappedMintHasNoMetadata => "Error: UnwrappedMintHasNoMetadata",
+            TokenWrapError::MetaplexMetadataMismatch => "Error: MetaplexMetadataMismatch",
         }
     }
 }

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -5,6 +5,7 @@
 mod entrypoint;
 pub mod error;
 pub mod instruction;
+pub mod metaplex;
 pub mod mint_customizer;
 pub mod processor;
 pub mod state;

--- a/program/src/metaplex.rs
+++ b/program/src/metaplex.rs
@@ -1,0 +1,98 @@
+//! `Metaplex` related helpers
+
+use {
+    mpl_token_metadata::accounts::Metadata as MetaplexMetadata, solana_account_info::AccountInfo,
+    solana_program_error::ProgramError, spl_pod::optional_keys::OptionalNonZeroPubkey,
+    spl_token_metadata_interface::state::TokenMetadata,
+};
+
+fn extract_additional_metadata(
+    metaplex_metadata: &MetaplexMetadata,
+) -> Result<Vec<(String, String)>, ProgramError> {
+    let mut additional_metadata = vec![
+        (
+            "key".to_string(),
+            serde_json::to_string(&metaplex_metadata.key)
+                .map_err(|_| ProgramError::InvalidAccountData)?,
+        ),
+        (
+            "seller_fee_basis_points".to_string(),
+            metaplex_metadata.seller_fee_basis_points.to_string(),
+        ),
+        (
+            "primary_sale_happened".to_string(),
+            metaplex_metadata.primary_sale_happened.to_string(),
+        ),
+        (
+            "is_mutable".to_string(),
+            metaplex_metadata.is_mutable.to_string(),
+        ),
+    ];
+
+    if let Some(creators) = &metaplex_metadata.creators {
+        if !creators.is_empty() {
+            additional_metadata.push((
+                "creators".to_string(),
+                serde_json::to_string(creators).map_err(|_| ProgramError::InvalidAccountData)?,
+            ));
+        }
+    }
+    if let Some(edition_nonce) = metaplex_metadata.edition_nonce {
+        additional_metadata.push(("edition_nonce".to_string(), edition_nonce.to_string()));
+    }
+    if let Some(token_standard) = &metaplex_metadata.token_standard {
+        additional_metadata.push((
+            "token_standard".to_string(),
+            serde_json::to_string(token_standard).map_err(|_| ProgramError::InvalidAccountData)?,
+        ));
+    }
+    if let Some(collection) = &metaplex_metadata.collection {
+        additional_metadata.push((
+            "collection".to_string(),
+            serde_json::to_string(collection).map_err(|_| ProgramError::InvalidAccountData)?,
+        ));
+    }
+    if let Some(uses) = &metaplex_metadata.uses {
+        additional_metadata.push((
+            "uses".to_string(),
+            serde_json::to_string(uses).map_err(|_| ProgramError::InvalidAccountData)?,
+        ));
+    }
+    if let Some(collection_details) = &metaplex_metadata.collection_details {
+        additional_metadata.push((
+            "collection_details".to_string(),
+            serde_json::to_string(collection_details)
+                .map_err(|_| ProgramError::InvalidAccountData)?,
+        ));
+    }
+    if let Some(programmable_config) = &metaplex_metadata.programmable_config {
+        additional_metadata.push((
+            "programmable_config".to_string(),
+            serde_json::to_string(programmable_config)
+                .map_err(|_| ProgramError::InvalidAccountData)?,
+        ));
+    }
+
+    Ok(additional_metadata)
+}
+
+/// Converts `Metaplex` metadata to the Token-2022 `TokenMetadata` format.
+pub fn metaplex_to_token_2022_metadata(
+    unwrapped_mint_info: &AccountInfo,
+    metaplex_metadata_info: &AccountInfo,
+) -> Result<TokenMetadata, ProgramError> {
+    let metaplex_data = metaplex_metadata_info.try_borrow_data()?;
+    let metaplex_metadata = MetaplexMetadata::safe_deserialize(&metaplex_data)
+        .map_err(|_| ProgramError::InvalidAccountData)?;
+
+    let additional_metadata = extract_additional_metadata(&metaplex_metadata)?;
+
+    Ok(TokenMetadata {
+        update_authority: OptionalNonZeroPubkey(metaplex_metadata.update_authority),
+        mint: *unwrapped_mint_info.key,
+        name: metaplex_metadata.name,
+        symbol: metaplex_metadata.symbol,
+        uri: metaplex_metadata.uri,
+        additional_metadata,
+    })
+}

--- a/program/tests/helpers/sync_metadata_builder.rs
+++ b/program/tests/helpers/sync_metadata_builder.rs
@@ -62,8 +62,8 @@ impl<'a> SyncMetadataBuilder<'a> {
         self
     }
 
-    pub fn metaplex_metadata(mut self, account: Option<KeyedAccount>) -> Self {
-        self.metaplex_metadata = account;
+    pub fn metaplex_metadata(mut self, account: KeyedAccount) -> Self {
+        self.metaplex_metadata = Some(account);
         self
     }
 

--- a/program/tests/test_sync_metadata_to_token_2022.rs
+++ b/program/tests/test_sync_metadata_to_token_2022.rs
@@ -200,7 +200,7 @@ fn test_fail_sync_metadata_with_wrong_metaplex_owner() {
 
     SyncMetadataBuilder::new()
         .unwrapped_mint(unwrapped_mint)
-        .metaplex_metadata(Some(malicious_metadata_account))
+        .metaplex_metadata(malicious_metadata_account)
         .check(Check::err(ProgramError::InvalidAccountOwner))
         .execute();
 }
@@ -220,7 +220,7 @@ fn test_fail_spl_token_with_invalid_metaplex_pda() {
 
     SyncMetadataBuilder::new()
         .unwrapped_mint(unwrapped_mint)
-        .metaplex_metadata(Some(invalid_metaplex_pda))
+        .metaplex_metadata(invalid_metaplex_pda)
         .check(Check::err(TokenWrapError::MetaplexMetadataMismatch.into()))
         .execute();
 }
@@ -242,7 +242,7 @@ fn test_fail_spl_token_without_metaplex_metadata() {
 
     SyncMetadataBuilder::new()
         .unwrapped_mint(unwrapped_mint)
-        .metaplex_metadata(Some(missing_metaplex_account))
+        .metaplex_metadata(missing_metaplex_account)
         .check(Check::err(ProgramError::InvalidAccountData))
         .execute();
 }
@@ -502,7 +502,7 @@ fn test_success_initialize_from_spl_token() {
     let result = SyncMetadataBuilder::new()
         .unwrapped_mint(unwrapped_mint)
         .wrapped_mint(wrapped_mint.clone())
-        .metaplex_metadata(Some(metaplex_metadata))
+        .metaplex_metadata(metaplex_metadata)
         .execute();
 
     let wrapped_mint_state =
@@ -585,7 +585,7 @@ fn test_success_update_from_spl_token() {
     let result = SyncMetadataBuilder::new()
         .unwrapped_mint(unwrapped_mint)
         .wrapped_mint(wrapped_mint.clone())
-        .metaplex_metadata(Some(metaplex_metadata))
+        .metaplex_metadata(metaplex_metadata)
         .execute();
 
     let wrapped_mint_state =

--- a/program/tests/test_sync_metadata_to_token_2022.rs
+++ b/program/tests/test_sync_metadata_to_token_2022.rs
@@ -5,9 +5,14 @@ use {
         mint_builder::MintBuilder,
         sync_metadata_builder::SyncMetadataBuilder,
     },
+    borsh::BorshSerialize,
     mollusk_svm::{program::create_program_account_loader_v3, result::Check},
+    mpl_token_metadata::{
+        accounts::Metadata as MetaplexMetadata,
+        types::{Collection, CollectionDetails, Creator, Key, TokenStandard, UseMethod, Uses},
+    },
     solana_account::Account,
-    solana_instruction::{AccountMeta, Instruction},
+    solana_instruction::AccountMeta,
     solana_program_error::ProgramError,
     solana_pubkey::Pubkey,
     spl_token_2022::{
@@ -17,19 +22,241 @@ use {
     spl_token_metadata_interface::state::TokenMetadata,
     spl_token_wrap::{
         error::TokenWrapError, get_wrapped_mint_address, get_wrapped_mint_authority, id,
-        instruction::TokenWrapInstruction,
+        instruction::sync_metadata_to_token_2022,
     },
+    std::collections::HashMap,
 };
 
 pub mod helpers;
 
 #[test]
-fn test_success_initialize_metadata() {
+fn test_fail_incorrect_token_program() {
+    let mollusk = init_mollusk();
+    let unwrapped_mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken2022)
+        .with_extension(MintExtension::TokenMetadata {
+            name: "N".to_string(),
+            symbol: "S".to_string(),
+            uri: "U".to_string(),
+            additional_metadata: vec![],
+        })
+        .build();
+    let wrapped_mint_address = get_wrapped_mint_address(&unwrapped_mint.key, &spl_token_2022::id());
+    let wrapped_mint_authority = get_wrapped_mint_authority(&wrapped_mint_address);
+    let wrapped_mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken2022)
+        .mint_key(wrapped_mint_address)
+        .build();
+
+    // Pass a fake program account instead of the real Token-2022 program
+    let fake_program = KeyedAccount {
+        key: Pubkey::new_unique(),
+        account: create_program_account_loader_v3(&Pubkey::new_unique()),
+    };
+
+    let mut instruction = sync_metadata_to_token_2022(
+        &id(),
+        &wrapped_mint.key,
+        &wrapped_mint_authority,
+        &unwrapped_mint.key,
+        None,
+    );
+
+    instruction.accounts[3] = AccountMeta::new_readonly(fake_program.key, false);
+
+    let accounts = &[
+        wrapped_mint.pair(),
+        (wrapped_mint_authority, Account::default()),
+        unwrapped_mint.pair(),
+        fake_program.pair(),
+        TokenProgram::SplToken2022.keyed_account(),
+    ];
+
+    mollusk.process_and_validate_instruction(
+        &instruction,
+        accounts,
+        &[Check::err(ProgramError::IncorrectProgramId)],
+    );
+}
+
+#[test]
+fn test_fail_wrapped_mint_not_token_2022() {
+    let unwrapped_mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken2022)
+        .with_extension(MintExtension::TokenMetadata {
+            name: "N".to_string(),
+            symbol: "S".to_string(),
+            uri: "U".to_string(),
+            additional_metadata: vec![],
+        })
+        .build();
+    let wrapped_mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken) // Invalid program
+        .mint_key(get_wrapped_mint_address(
+            &unwrapped_mint.key,
+            &spl_token_2022::id(),
+        ))
+        .build();
+
+    SyncMetadataBuilder::new()
+        .unwrapped_mint(unwrapped_mint)
+        .wrapped_mint(wrapped_mint)
+        .check(Check::err(ProgramError::IncorrectProgramId))
+        .execute();
+}
+
+#[test]
+fn test_fail_wrapped_mint_pda_mismatch() {
+    let wrong_wrapped_mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken2022)
+        .mint_key(Pubkey::new_unique()) // Not the derived PDA
+        .build();
+
+    SyncMetadataBuilder::new()
+        .wrapped_mint(wrong_wrapped_mint)
+        .check(Check::err(TokenWrapError::WrappedMintMismatch.into()))
+        .execute();
+}
+
+#[test]
+fn test_fail_wrapped_mint_authority_pda_mismatch() {
+    SyncMetadataBuilder::new()
+        .wrapped_mint_authority(Pubkey::new_unique()) // Not the derived PDA
+        .check(Check::err(TokenWrapError::MintAuthorityMismatch.into()))
+        .execute();
+}
+
+#[test]
+fn test_fail_unwrapped_mint_has_no_metadata() {
+    let unwrapped_mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken2022)
+        .build(); // No metadata extension
+
+    SyncMetadataBuilder::new()
+        .unwrapped_mint(unwrapped_mint)
+        .check(Check::err(
+            TokenWrapError::UnwrappedMintHasNoMetadata.into(),
+        ))
+        .execute();
+}
+
+#[test]
+fn test_fail_spl_token_missing_metaplex_account() {
+    let mollusk = init_mollusk();
+
+    let unwrapped_mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken)
+        .build();
+
+    let wrapped_mint_address = get_wrapped_mint_address(&unwrapped_mint.key, &spl_token_2022::id());
+    let wrapped_mint_authority = get_wrapped_mint_authority(&wrapped_mint_address);
+
+    let wrapped_mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken2022)
+        .mint_key(wrapped_mint_address)
+        .mint_authority(wrapped_mint_authority)
+        .with_extension(MetadataPointerExt)
+        .lamports(1_000_000_000)
+        .build();
+
+    let instruction = sync_metadata_to_token_2022(
+        &id(),
+        &wrapped_mint.key,
+        &wrapped_mint_authority,
+        &unwrapped_mint.key,
+        None, // Metaplex account is omitted
+    );
+
+    let accounts = &[
+        wrapped_mint.pair(),
+        (wrapped_mint_authority, Account::default()),
+        unwrapped_mint.pair(),
+        TokenProgram::SplToken2022.keyed_account(),
+    ];
+
+    mollusk.process_and_validate_instruction(
+        &instruction,
+        accounts,
+        &[Check::err(ProgramError::NotEnoughAccountKeys)],
+    );
+}
+
+#[test]
+fn test_fail_sync_metadata_with_wrong_metaplex_owner() {
+    let unwrapped_mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken)
+        .build();
+
+    let (metaplex_pda, _) = MetaplexMetadata::find_pda(&unwrapped_mint.key);
+
+    let malicious_metadata_account = KeyedAccount {
+        key: metaplex_pda,
+        account: Account {
+            lamports: 1_000_000_000,
+            owner: Pubkey::new_unique(), // fake metadata account owner
+            ..Default::default()
+        },
+    };
+
+    SyncMetadataBuilder::new()
+        .unwrapped_mint(unwrapped_mint)
+        .metaplex_metadata(Some(malicious_metadata_account))
+        .check(Check::err(ProgramError::InvalidAccountOwner))
+        .execute();
+}
+
+#[test]
+fn test_fail_spl_token_with_invalid_metaplex_pda() {
+    let unwrapped_mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken)
+        .build();
+    let invalid_metaplex_pda = KeyedAccount {
+        key: Pubkey::new_unique(),
+        account: Account {
+            owner: mpl_token_metadata::ID, // Correct owner
+            ..Default::default()
+        },
+    };
+
+    SyncMetadataBuilder::new()
+        .unwrapped_mint(unwrapped_mint)
+        .metaplex_metadata(Some(invalid_metaplex_pda))
+        .check(Check::err(TokenWrapError::MetaplexMetadataMismatch.into()))
+        .execute();
+}
+
+#[test]
+fn test_fail_spl_token_without_metaplex_metadata() {
+    let unwrapped_mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken)
+        .build();
+
+    let (metaplex_pda, _) = MetaplexMetadata::find_pda(&unwrapped_mint.key);
+    let missing_metaplex_account = KeyedAccount {
+        key: metaplex_pda,
+        account: Account {
+            owner: mpl_token_metadata::ID, // Correct owner, but no data
+            ..Default::default()
+        },
+    };
+
+    SyncMetadataBuilder::new()
+        .unwrapped_mint(unwrapped_mint)
+        .metaplex_metadata(Some(missing_metaplex_account))
+        .check(Check::err(ProgramError::InvalidAccountData))
+        .execute();
+}
+
+#[test]
+fn test_success_initialize_from_token_2022() {
     let unwrapped_metadata = MintExtension::TokenMetadata {
         name: "Unwrapped Token".to_string(),
         symbol: "UWT".to_string(),
         uri: "https://unwrapped.dev/meta.json".to_string(),
-        additional_metadata: vec![],
+        additional_metadata: vec![
+            ("key1".to_string(), "value1".to_string()),
+            ("key2".to_string(), "value2".to_string()),
+        ],
     };
     let unwrapped_mint = MintBuilder::new()
         .token_program(TokenProgram::SplToken2022)
@@ -79,135 +306,7 @@ fn test_success_initialize_metadata() {
 }
 
 #[test]
-fn test_success_initialize_metadata_with_additional_fields() {
-    let unwrapped_metadata = MintExtension::TokenMetadata {
-        name: "Unwrapped Token".to_string(),
-        symbol: "UWT".to_string(),
-        uri: "https://unwrapped.dev/meta.json".to_string(),
-        additional_metadata: vec![
-            ("key1".to_string(), "value1".to_string()),
-            ("key2".to_string(), "value2".to_string()),
-        ],
-    };
-    let unwrapped_mint = MintBuilder::new()
-        .token_program(TokenProgram::SplToken2022)
-        .with_extension(unwrapped_metadata.clone())
-        .build();
-
-    let wrapped_mint = MintBuilder::new()
-        .token_program(TokenProgram::SplToken2022)
-        .mint_key(get_wrapped_mint_address(
-            &unwrapped_mint.key,
-            &spl_token_2022::id(),
-        ))
-        .mint_authority(get_wrapped_mint_authority(&get_wrapped_mint_address(
-            &unwrapped_mint.key,
-            &spl_token_2022::id(),
-        )))
-        .with_extension(MetadataPointerExt)
-        .lamports(1_000_000_000)
-        .build();
-
-    let result = SyncMetadataBuilder::new()
-        .unwrapped_mint(unwrapped_mint)
-        .wrapped_mint(wrapped_mint.clone())
-        .execute();
-
-    let wrapped_mint_state =
-        PodStateWithExtensions::<PodMint>::unpack(&result.wrapped_mint.account.data).unwrap();
-    let wrapped_metadata = wrapped_mint_state
-        .get_variable_len_extension::<TokenMetadata>()
-        .unwrap();
-
-    if let MintExtension::TokenMetadata {
-        name,
-        symbol,
-        uri,
-        additional_metadata,
-    } = unwrapped_metadata
-    {
-        assert_eq!(wrapped_metadata.name, name);
-        assert_eq!(wrapped_metadata.symbol, symbol);
-        assert_eq!(wrapped_metadata.uri, uri);
-        assert_eq!(wrapped_metadata.additional_metadata, additional_metadata);
-        assert_eq!(
-            Option::<Pubkey>::from(wrapped_metadata.update_authority).unwrap(),
-            result.wrapped_mint_authority.key
-        );
-        assert_eq!(wrapped_metadata.mint, wrapped_mint.key);
-    } else {
-        panic!("destructure failed");
-    }
-}
-
-#[test]
-fn test_success_update_metadata() {
-    // Wrapped mint with old metadata that needs to be updated
-    let old_metadata = MintExtension::TokenMetadata {
-        name: "Old Name".to_string(),
-        symbol: "OLD".to_string(),
-        uri: "https://old.uri".to_string(),
-        additional_metadata: vec![],
-    };
-
-    // Unwrapped mint with the new metadata
-    let new_metadata = MintExtension::TokenMetadata {
-        name: "Updated Name".to_string(),
-        symbol: "UPD".to_string(),
-        uri: "https://updated.uri".to_string(),
-        additional_metadata: vec![],
-    };
-
-    let unwrapped_mint = MintBuilder::new()
-        .token_program(TokenProgram::SplToken2022)
-        .with_extension(new_metadata.clone())
-        .build();
-
-    let wrapped_mint_address = get_wrapped_mint_address(&unwrapped_mint.key, &spl_token_2022::id());
-    let wrapped_mint_authority = get_wrapped_mint_authority(&wrapped_mint_address);
-    let wrapped_mint = MintBuilder::new()
-        .token_program(TokenProgram::SplToken2022)
-        .mint_key(wrapped_mint_address)
-        .mint_authority(wrapped_mint_authority)
-        .with_extension(MetadataPointerExt)
-        .with_extension(old_metadata)
-        .lamports(1_000_000_000)
-        .build();
-
-    let result = SyncMetadataBuilder::new()
-        .unwrapped_mint(unwrapped_mint)
-        .wrapped_mint(wrapped_mint.clone())
-        .execute();
-
-    let wrapped_mint_state =
-        PodStateWithExtensions::<PodMint>::unpack(&result.wrapped_mint.account.data).unwrap();
-    let wrapped_metadata = wrapped_mint_state
-        .get_variable_len_extension::<TokenMetadata>()
-        .unwrap();
-
-    if let MintExtension::TokenMetadata {
-        name,
-        symbol,
-        uri,
-        additional_metadata,
-    } = new_metadata
-    {
-        assert_eq!(wrapped_metadata.name, name);
-        assert_eq!(wrapped_metadata.symbol, symbol);
-        assert_eq!(wrapped_metadata.uri, uri);
-        assert_eq!(wrapped_metadata.additional_metadata, additional_metadata);
-        assert_eq!(
-            Option::<Pubkey>::from(wrapped_metadata.update_authority).unwrap(),
-            result.wrapped_mint_authority.key
-        );
-        assert_eq!(wrapped_metadata.mint, wrapped_mint.key);
-    } else {
-        panic!("destructure failed");
-    }
-}
-
-#[test]
-fn test_success_update_metadata_with_additional_fields() {
+fn test_success_update_from_token_2022() {
     let old_metadata = MintExtension::TokenMetadata {
         name: "Old Name".to_string(),
         symbol: "SYM".to_string(),
@@ -275,126 +374,236 @@ fn test_success_update_metadata_with_additional_fields() {
     }
 }
 
-#[test]
-fn test_fail_unwrapped_mint_has_no_metadata() {
-    let unwrapped_mint = MintBuilder::new()
-        .token_program(TokenProgram::SplToken2022)
-        .build(); // No metadata extension
+fn assert_metaplex_fields_synced(
+    wrapped_metadata: &TokenMetadata,
+    metaplex_metadata: &MetaplexMetadata,
+) {
+    let additional_meta_map: HashMap<_, _> = wrapped_metadata
+        .additional_metadata
+        .iter()
+        .cloned()
+        .collect();
 
-    SyncMetadataBuilder::new()
-        .unwrapped_mint(unwrapped_mint)
-        .check(Check::err(
-            TokenWrapError::UnwrappedMintHasNoMetadata.into(),
-        ))
-        .execute();
+    assert_eq!(
+        additional_meta_map.get("seller_fee_basis_points").unwrap(),
+        &metaplex_metadata.seller_fee_basis_points.to_string()
+    );
+    assert_eq!(
+        additional_meta_map.get("primary_sale_happened").unwrap(),
+        &metaplex_metadata.primary_sale_happened.to_string()
+    );
+    assert_eq!(
+        additional_meta_map.get("is_mutable").unwrap(),
+        &metaplex_metadata.is_mutable.to_string()
+    );
+    if let Some(edition_nonce) = metaplex_metadata.edition_nonce {
+        assert_eq!(
+            additional_meta_map.get("edition_nonce").unwrap(),
+            &edition_nonce.to_string()
+        );
+    }
+    if let Some(token_standard) = &metaplex_metadata.token_standard {
+        assert_eq!(
+            additional_meta_map.get("token_standard").unwrap(),
+            &serde_json::to_string(token_standard).unwrap()
+        );
+    }
+    if let Some(collection) = &metaplex_metadata.collection {
+        assert_eq!(
+            additional_meta_map.get("collection").unwrap(),
+            &serde_json::to_string(collection).unwrap()
+        );
+    }
+    if let Some(uses) = &metaplex_metadata.uses {
+        assert_eq!(
+            additional_meta_map.get("uses").unwrap(),
+            &serde_json::to_string(uses).unwrap()
+        );
+    }
+    if let Some(collection_details) = &metaplex_metadata.collection_details {
+        assert_eq!(
+            additional_meta_map.get("collection_details").unwrap(),
+            &serde_json::to_string(collection_details).unwrap()
+        );
+    }
+    if let Some(creators) = &metaplex_metadata.creators {
+        if !creators.is_empty() {
+            assert_eq!(
+                additional_meta_map.get("creators").unwrap(),
+                &serde_json::to_string(creators).unwrap()
+            );
+        }
+    }
+    if let Some(config) = &metaplex_metadata.programmable_config {
+        assert_eq!(
+            additional_meta_map.get("config").unwrap(),
+            &serde_json::to_string(config).unwrap()
+        );
+    }
 }
 
 #[test]
-fn test_fail_incorrect_token_program() {
-    let mollusk = init_mollusk();
+fn test_success_initialize_from_spl_token() {
     let unwrapped_mint = MintBuilder::new()
-        .token_program(TokenProgram::SplToken2022)
-        .with_extension(MintExtension::TokenMetadata {
-            name: "N".to_string(),
-            symbol: "S".to_string(),
-            uri: "U".to_string(),
-            additional_metadata: vec![],
-        })
+        .token_program(TokenProgram::SplToken)
         .build();
+
+    let metaplex_metadata_obj = MetaplexMetadata {
+        key: Key::MetadataV1,
+        update_authority: Pubkey::new_unique(),
+        mint: unwrapped_mint.key,
+        name: "Spiderman Token".to_string(),
+        symbol: "SPDR".to_string(),
+        uri: "https://metaplex.dev/meta.json".to_string(),
+        seller_fee_basis_points: 100,
+        creators: Some(vec![Creator {
+            address: Pubkey::new_unique(),
+            verified: true,
+            share: 100,
+        }]),
+        primary_sale_happened: true,
+        is_mutable: false,
+        edition_nonce: Some(1),
+        token_standard: Some(TokenStandard::NonFungible),
+        collection: Some(Collection {
+            verified: false,
+            key: Pubkey::new_unique(),
+        }),
+        uses: Some(Uses {
+            use_method: UseMethod::Burn,
+            remaining: 1,
+            total: 1,
+        }),
+        collection_details: Some(CollectionDetails::V1 { size: 1 }),
+        programmable_config: None,
+    };
+
+    let metaplex_metadata = KeyedAccount {
+        key: MetaplexMetadata::find_pda(&unwrapped_mint.key).0,
+        account: Account {
+            lamports: 1_000_000_000,
+            data: metaplex_metadata_obj.try_to_vec().unwrap(),
+            owner: mpl_token_metadata::ID,
+            ..Default::default()
+        },
+    };
+
+    let wrapped_mint_address = get_wrapped_mint_address(&unwrapped_mint.key, &spl_token_2022::id());
+    let wrapped_mint_authority = get_wrapped_mint_authority(&wrapped_mint_address);
+
+    let wrapped_mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken2022)
+        .mint_key(wrapped_mint_address)
+        .mint_authority(wrapped_mint_authority)
+        .with_extension(MetadataPointerExt)
+        .lamports(1_000_000_000)
+        .build();
+
+    let result = SyncMetadataBuilder::new()
+        .unwrapped_mint(unwrapped_mint)
+        .wrapped_mint(wrapped_mint.clone())
+        .metaplex_metadata(Some(metaplex_metadata))
+        .execute();
+
+    let wrapped_mint_state =
+        PodStateWithExtensions::<PodMint>::unpack(&result.wrapped_mint.account.data).unwrap();
+    let wrapped_metadata = wrapped_mint_state
+        .get_variable_len_extension::<TokenMetadata>()
+        .unwrap();
+
+    // Assert base fields
+    assert_eq!(wrapped_metadata.name, "Spiderman Token");
+    assert_eq!(wrapped_metadata.symbol, "SPDR");
+    assert_eq!(wrapped_metadata.uri, "https://metaplex.dev/meta.json");
+    assert_eq!(
+        Option::<Pubkey>::from(wrapped_metadata.update_authority).unwrap(),
+        result.wrapped_mint_authority.key
+    );
+    assert_eq!(wrapped_metadata.mint, wrapped_mint.key);
+
+    // Assert additional metadata fields
+    assert_metaplex_fields_synced(&wrapped_metadata, &metaplex_metadata_obj);
+}
+
+#[test]
+fn test_success_update_from_spl_token() {
+    let unwrapped_mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken)
+        .build();
+
+    let old_wrapped_metadata = MintExtension::TokenMetadata {
+        name: "Old Wrapped Name".to_string(),
+        symbol: "OLD".to_string(),
+        uri: "https://old.uri/".to_string(),
+        additional_metadata: vec![("seller_fee_basis_points".to_string(), "50".to_string())],
+    };
+
     let wrapped_mint_address = get_wrapped_mint_address(&unwrapped_mint.key, &spl_token_2022::id());
     let wrapped_mint_authority = get_wrapped_mint_authority(&wrapped_mint_address);
     let wrapped_mint = MintBuilder::new()
         .token_program(TokenProgram::SplToken2022)
         .mint_key(wrapped_mint_address)
+        .mint_authority(wrapped_mint_authority)
+        .with_extension(MintExtension::MetadataPointer)
+        .with_extension(old_wrapped_metadata)
+        .lamports(1_000_000_000)
         .build();
 
-    // Pass a fake program account instead of the real Token-2022 program
-    let fake_program = KeyedAccount {
-        key: Pubkey::new_unique(),
-        account: create_program_account_loader_v3(&Pubkey::new_unique()),
+    let new_metaplex_metadata_obj = MetaplexMetadata {
+        key: Key::MetadataV1,
+        update_authority: Pubkey::new_unique(),
+        mint: unwrapped_mint.key,
+        name: "DocOct Token".to_string(),
+        symbol: "OCT".to_string(),
+        uri: "https://new.uri/".to_string(),
+        seller_fee_basis_points: 200,
+        creators: Some(vec![Creator {
+            address: Pubkey::new_unique(),
+            verified: false,
+            share: 100,
+        }]),
+        primary_sale_happened: false,
+        is_mutable: true,
+        edition_nonce: Some(2),
+        token_standard: Some(TokenStandard::Fungible),
+        collection: None,
+        uses: None,
+        collection_details: None,
+        programmable_config: None,
     };
 
-    let instruction = Instruction {
-        program_id: id(),
-        accounts: vec![
-            AccountMeta::new(wrapped_mint.key, false),
-            AccountMeta::new_readonly(wrapped_mint_authority, false),
-            AccountMeta::new_readonly(unwrapped_mint.key, false),
-            AccountMeta::new_readonly(fake_program.key, false),
-        ],
-        data: TokenWrapInstruction::SyncMetadataToToken2022.pack(),
+    let metaplex_metadata = KeyedAccount {
+        key: MetaplexMetadata::find_pda(&unwrapped_mint.key).0,
+        account: Account {
+            lamports: 1_000_000_000,
+            data: new_metaplex_metadata_obj.try_to_vec().unwrap(),
+            owner: mpl_token_metadata::ID,
+            ..Default::default()
+        },
     };
 
-    let accounts = &[
-        wrapped_mint.pair(),
-        (wrapped_mint_authority, Account::default()),
-        unwrapped_mint.pair(),
-        fake_program.pair(),
-    ];
+    let result = SyncMetadataBuilder::new()
+        .unwrapped_mint(unwrapped_mint)
+        .wrapped_mint(wrapped_mint.clone())
+        .metaplex_metadata(Some(metaplex_metadata))
+        .execute();
 
-    mollusk.process_and_validate_instruction(
-        &instruction,
-        accounts,
-        &[Check::err(ProgramError::IncorrectProgramId)],
+    let wrapped_mint_state =
+        PodStateWithExtensions::<PodMint>::unpack(&result.wrapped_mint.account.data).unwrap();
+    let wrapped_metadata = wrapped_mint_state
+        .get_variable_len_extension::<TokenMetadata>()
+        .unwrap();
+
+    // Assert base fields
+    assert_eq!(wrapped_metadata.name, "DocOct Token");
+    assert_eq!(wrapped_metadata.symbol, "OCT");
+    assert_eq!(wrapped_metadata.uri, "https://new.uri/");
+    assert_eq!(
+        Option::<Pubkey>::from(wrapped_metadata.update_authority).unwrap(),
+        result.wrapped_mint_authority.key
     );
-}
+    assert_eq!(wrapped_metadata.mint, wrapped_mint.key);
 
-// TODO: Remove test when spl-token supported
-#[test]
-fn test_fail_unwrapped_mint_not_token_2022() {
-    let unwrapped_mint = MintBuilder::new()
-        .token_program(TokenProgram::SplToken)
-        .build();
-
-    SyncMetadataBuilder::new()
-        .unwrapped_mint(unwrapped_mint)
-        .check(Check::err(ProgramError::IncorrectProgramId))
-        .execute();
-}
-
-#[test]
-fn test_fail_wrapped_mint_not_token_2022() {
-    let unwrapped_mint = MintBuilder::new()
-        .token_program(TokenProgram::SplToken2022)
-        .with_extension(MintExtension::TokenMetadata {
-            name: "N".to_string(),
-            symbol: "S".to_string(),
-            uri: "U".to_string(),
-            additional_metadata: vec![],
-        })
-        .build();
-    let wrapped_mint = MintBuilder::new()
-        .token_program(TokenProgram::SplToken) // Invalid program
-        .mint_key(get_wrapped_mint_address(
-            &unwrapped_mint.key,
-            &spl_token_2022::id(),
-        ))
-        .build();
-
-    SyncMetadataBuilder::new()
-        .unwrapped_mint(unwrapped_mint)
-        .wrapped_mint(wrapped_mint)
-        .check(Check::err(ProgramError::IncorrectProgramId))
-        .execute();
-}
-
-#[test]
-fn test_fail_wrapped_mint_pda_mismatch() {
-    let wrong_wrapped_mint = MintBuilder::new()
-        .token_program(TokenProgram::SplToken2022)
-        .mint_key(Pubkey::new_unique()) // Not the derived PDA
-        .build();
-
-    SyncMetadataBuilder::new()
-        .wrapped_mint(wrong_wrapped_mint)
-        .check(Check::err(TokenWrapError::WrappedMintMismatch.into()))
-        .execute();
-}
-
-#[test]
-fn test_fail_wrapped_mint_authority_pda_mismatch() {
-    SyncMetadataBuilder::new()
-        .wrapped_mint_authority(Pubkey::new_unique()) // Not the derived PDA
-        .check(Check::err(TokenWrapError::MintAuthorityMismatch.into()))
-        .execute();
+    // Assert additional metadata fields
+    assert_metaplex_fields_synced(&wrapped_metadata, &new_metaplex_metadata_obj);
 }


### PR DESCRIPTION
This PR extends the `SyncMetadataToToken2022` instruction to support syncing metadata from an spl-token's metaplex PDA to the wrapped token's metadata extension.

Note that this copies over non-overlapping fields as `addditional_metadata` serialized to json. Up for discussion if this is ok or overkill. 