### PR TITLE
Pointer-aware metadata sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3346,6 +3346,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "mock-metadata-owner"
+version = "0.1.0"
+dependencies = [
+ "solana-account-info",
+ "solana-cpi",
+ "solana-program-entrypoint",
+ "solana-program-error",
+ "solana-pubkey",
+ "spl-token-2022 9.0.0",
+ "spl-token-metadata-interface",
+]
+
+[[package]]
 name = "mockall"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9780,6 +9793,7 @@ version = "0.1.0"
 dependencies = [
  "borsh 0.10.4",
  "bytemuck",
+ "mock-metadata-owner",
  "mollusk-svm",
  "mollusk-svm-programs-token",
  "mpl-token-metadata",
@@ -9793,7 +9807,6 @@ dependencies = [
  "solana-msg",
  "solana-program-entrypoint",
  "solana-program-error",
- "solana-program-option",
  "solana-program-pack",
  "solana-pubkey",
  "solana-rent",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,11 @@
 [workspace]
 resolver = "2"
-members = ["clients/cli", "program", "program/tests/programs/test-transfer-hook"]
+members = [
+    "clients/cli",
+    "program",
+    "program/tests/programs/test-transfer-hook",
+    "program/tests/programs/mock-metadata-owner"
+]
 
 [workspace.metadata.cli]
 solana = "2.3.4"
@@ -34,6 +39,7 @@ anyhow = "1.0.98"
 borsh = "0.10.4"
 bytemuck = { version = "1.23.2", features = ["derive"] }
 clap = { version = "3.2.25", features = ["derive"] }
+mock-metadata-owner = { path = "program/tests/programs/mock-metadata-owner" }
 mollusk-svm = "0.4.2"
 mollusk-svm-programs-token = "0.4.1"
 mpl-token-metadata = "5.1.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "programs:build": "cargo-build-sbf --manifest-path program/Cargo.toml && cargo-build-sbf --manifest-path program/tests/programs/test-transfer-hook/Cargo.toml",
+    "programs:build": "cargo-build-sbf --manifest-path program/Cargo.toml && cargo-build-sbf --manifest-path program/tests/programs/test-transfer-hook/Cargo.toml && cargo-build-sbf --manifest-path program/tests/programs/mock-metadata-owner/Cargo.toml",
     "programs:test": "zx ./scripts/rust/test-sbf.mjs program",
     "programs:format": "zx ./scripts/rust/format.mjs program",
     "programs:lint": "zx ./scripts/rust/lint.mjs program",

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -23,7 +23,6 @@ solana-instruction = { workspace = true }
 solana-msg = { workspace = true }
 solana-program-entrypoint = { workspace = true }
 solana-program-error = { workspace = true }
-solana-program-option = { workspace = true }
 solana-program-pack = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-rent = { workspace = true }
@@ -34,6 +33,7 @@ spl-pod = { workspace = true }
 spl-token = { workspace = true }
 spl-token-metadata-interface = { workspace = true }
 spl-transfer-hook-interface = { workspace = true }
+spl-type-length-value = { workspace = true }
 thiserror = { workspace = true }
 
 # Should depend on the next crate version after 7.0.0 when https://github.com/solana-program/token-2022/pull/253 is deployed
@@ -41,10 +41,10 @@ spl-token-2022 = { workspace = true }
 
 [dev-dependencies]
 borsh = { workspace = true }
+mock-metadata-owner = { workspace = true }
 mollusk-svm = { workspace = true }
 mollusk-svm-programs-token = { workspace = true }
 solana-account = { workspace = true }
-spl-type-length-value = { workspace = true }
 spl-tlv-account-resolution = { workspace = true }
 test-case = { workspace = true }
 test-transfer-hook = { workspace = true }

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -50,6 +50,18 @@ pub enum TokenWrapError {
     /// `Metaplex` metadata account address does not match expected PDA
     #[error("Metaplex metadata account address does not match expected PDA")]
     MetaplexMetadataMismatch,
+    /// Metadata pointer extension missing on mint
+    #[error("Metadata pointer extension missing on mint")]
+    MetadataPointerMissing,
+    /// Metadata pointer is unset (None)
+    #[error("Metadata pointer is unset (None)")]
+    MetadataPointerUnset,
+    /// Provided source metadata account does not match pointer
+    #[error("Provided source metadata account does not match pointer")]
+    MetadataPointerMismatch,
+    /// External metadata program returned no data
+    #[error("External metadata program returned no data")]
+    ExternalProgramReturnedNoData,
 }
 
 impl From<TokenWrapError> for ProgramError {
@@ -83,6 +95,12 @@ impl ToStr for TokenWrapError {
             TokenWrapError::EscrowInGoodState => "Error: EscrowInGoodState",
             TokenWrapError::UnwrappedMintHasNoMetadata => "Error: UnwrappedMintHasNoMetadata",
             TokenWrapError::MetaplexMetadataMismatch => "Error: MetaplexMetadataMismatch",
+            TokenWrapError::MetadataPointerMissing => "Error: MetadataPointerMissing",
+            TokenWrapError::MetadataPointerUnset => "Error: MetadataPointerUnset",
+            TokenWrapError::MetadataPointerMismatch => "Error: MetadataPointerMismatch",
+            &TokenWrapError::ExternalProgramReturnedNoData => {
+                "Error: ExternalProgramReturnedNoData"
+            }
         }
     }
 }

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -112,17 +112,13 @@ pub enum TokenWrapInstruction {
     /// This instruction copies the metadata fields from an unwrapped mint to
     /// its wrapped mint `TokenMetadata` extension.
     ///
-    /// Token-2022 source (via `MetadataPointer`):
-    /// - `pointer == self`: Read `TokenMetadata` from the mint (no extra acct)
-    /// - `pointer -> Token-2022 account`: Read `TokenMetadata` from that
-    ///   account (must be passed)
-    /// - `pointer -> Metaplex PDA`: convert fields (must pass PDA)
-    /// - `pointer -> third-party program`: CPI `Emit` to the account owner and
-    ///   use returned fields (must pass the metadata account and its owner
-    ///   program).
+    /// Supports (unwrapped to wrapped):
+    /// - Token-2022 to Token-2022
+    /// - SPL-token to Token-2022
     ///
-    /// SPL Token source:
-    /// - `Metaplex` PDA: convert fields (must pass PDA)
+    /// If source mint is a Token-2022, it must have a `MetadataPointer` and the
+    /// account it points to must be provided. If source mint is an SPL-Token,
+    /// the `Metaplex` PDA must be provided.
     ///
     /// If the `TokenMetadata` extension on the wrapped mint if not present, it
     /// will initialize it. The client is responsible for funding the wrapped

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -5,6 +5,7 @@
 mod entrypoint;
 pub mod error;
 pub mod instruction;
+pub mod metadata;
 pub mod metaplex;
 pub mod mint_customizer;
 pub mod processor;

--- a/program/src/metadata.rs
+++ b/program/src/metadata.rs
@@ -1,0 +1,91 @@
+//! Metadata resolution helpers for pointer-aware metadata sync
+
+use {
+    crate::{error::TokenWrapError, metaplex::metaplex_to_token_2022_metadata},
+    mpl_token_metadata::ID as MPL_TOKEN_METADATA_ID,
+    solana_account_info::AccountInfo,
+    solana_cpi::{get_return_data, invoke},
+    solana_program_error::ProgramError,
+    spl_token_2022::{
+        extension::{
+            metadata_pointer::MetadataPointer, BaseStateWithExtensions, PodStateWithExtensions,
+        },
+        id as token_2022_id,
+        pod::PodMint,
+    },
+    spl_token_metadata_interface::{instruction::emit, state::TokenMetadata},
+    spl_type_length_value::variable_len_pack::VariableLenPack,
+};
+
+/// Fetches metadata from a third-party program implementing
+/// `TokenMetadataInstruction` by invoking its `Emit` instruction and decoding
+/// the `TokenMetadata` struct from the return data.
+pub fn cpi_emit_and_decode<'a>(
+    owner_program_info: &AccountInfo<'a>,
+    metadata_info: &AccountInfo<'a>,
+) -> Result<TokenMetadata, ProgramError> {
+    invoke(
+        &emit(owner_program_info.key, metadata_info.key, None, None),
+        &[metadata_info.clone()],
+    )?;
+
+    if let Some((program_key, data)) = get_return_data() {
+        // This check ensures this data comes from the program we just called
+        if program_key == *owner_program_info.key {
+            return TokenMetadata::unpack_from_slice(&data);
+        }
+    }
+
+    Err(TokenWrapError::ExternalProgramReturnedNoData.into())
+}
+
+/// Resolve the canonical metadata source for an unwrapped Token-2022 mint
+/// by following its `MetadataPointer`.
+///
+/// Supported pointer targets:
+/// - Self
+/// - Token-2022 account
+/// - `Metaplex` PDA
+/// - Third-party program
+pub fn resolve_token_2022_source_metadata<'a>(
+    unwrapped_mint_info: &AccountInfo<'a>,
+    maybe_source_metadata_info: Option<&AccountInfo<'a>>,
+    maybe_owner_program_info: Option<&AccountInfo<'a>>,
+) -> Result<TokenMetadata, ProgramError> {
+    let data = unwrapped_mint_info.try_borrow_data()?;
+    let mint_state = PodStateWithExtensions::<PodMint>::unpack(&data)?;
+    let pointer = mint_state
+        .get_extension::<MetadataPointer>()
+        .map_err(|_| TokenWrapError::MetadataPointerMissing)?;
+    let metadata_addr =
+        Option::from(pointer.metadata_address).ok_or(TokenWrapError::MetadataPointerUnset)?;
+
+    // Scenario 1: points to self, read off unwrapped mint
+    if metadata_addr == *unwrapped_mint_info.key {
+        return mint_state.get_variable_len_extension::<TokenMetadata>();
+    }
+
+    // Metadata account must be passed by this point
+    let metadata_info = maybe_source_metadata_info.ok_or(ProgramError::NotEnoughAccountKeys)?;
+    if metadata_info.key != &metadata_addr {
+        return Err(TokenWrapError::MetadataPointerMismatch.into());
+    }
+
+    if metadata_info.owner == &token_2022_id() {
+        // Scenario 2: points to another token-2022 mint
+        let data = metadata_info.try_borrow_data()?;
+        let state = PodStateWithExtensions::<PodMint>::unpack(&data)?;
+        state.get_variable_len_extension::<TokenMetadata>()
+    } else if metadata_info.owner == &MPL_TOKEN_METADATA_ID {
+        // Scenario 3: points to a Metaplex PDA
+        metaplex_to_token_2022_metadata(unwrapped_mint_info, metadata_info)
+    } else {
+        // Scenario 4: points to an external program
+        let owner_program_info =
+            maybe_owner_program_info.ok_or(ProgramError::NotEnoughAccountKeys)?;
+        if owner_program_info.key != metadata_info.owner {
+            return Err(ProgramError::InvalidAccountOwner);
+        }
+        cpi_emit_and_decode(owner_program_info, metadata_info)
+    }
+}

--- a/program/tests/helpers/common.rs
+++ b/program/tests/helpers/common.rs
@@ -64,6 +64,11 @@ pub fn init_mollusk() -> Mollusk {
         "test_transfer_hook",
         &mollusk_svm::program::loader_keys::LOADER_V3,
     );
+    mollusk.add_program(
+        &mock_metadata_owner::ID,
+        "mock_metadata_owner",
+        &mollusk_svm::program::loader_keys::LOADER_V3,
+    );
     mollusk
 }
 

--- a/program/tests/helpers/metadata.rs
+++ b/program/tests/helpers/metadata.rs
@@ -1,0 +1,72 @@
+use {
+    mpl_token_metadata::accounts::Metadata as MetaplexMetadata,
+    spl_token_metadata_interface::state::TokenMetadata, std::collections::HashMap,
+};
+
+pub fn assert_metaplex_fields_synced(
+    wrapped_metadata: &TokenMetadata,
+    metaplex_metadata: &MetaplexMetadata,
+) {
+    let additional_meta_map: HashMap<_, _> = wrapped_metadata
+        .additional_metadata
+        .iter()
+        .cloned()
+        .collect();
+
+    assert_eq!(
+        additional_meta_map.get("seller_fee_basis_points").unwrap(),
+        &metaplex_metadata.seller_fee_basis_points.to_string()
+    );
+    assert_eq!(
+        additional_meta_map.get("primary_sale_happened").unwrap(),
+        &metaplex_metadata.primary_sale_happened.to_string()
+    );
+    assert_eq!(
+        additional_meta_map.get("is_mutable").unwrap(),
+        &metaplex_metadata.is_mutable.to_string()
+    );
+    if let Some(edition_nonce) = metaplex_metadata.edition_nonce {
+        assert_eq!(
+            additional_meta_map.get("edition_nonce").unwrap(),
+            &edition_nonce.to_string()
+        );
+    }
+    if let Some(token_standard) = &metaplex_metadata.token_standard {
+        assert_eq!(
+            additional_meta_map.get("token_standard").unwrap(),
+            &serde_json::to_string(token_standard).unwrap()
+        );
+    }
+    if let Some(collection) = &metaplex_metadata.collection {
+        assert_eq!(
+            additional_meta_map.get("collection").unwrap(),
+            &serde_json::to_string(collection).unwrap()
+        );
+    }
+    if let Some(uses) = &metaplex_metadata.uses {
+        assert_eq!(
+            additional_meta_map.get("uses").unwrap(),
+            &serde_json::to_string(uses).unwrap()
+        );
+    }
+    if let Some(collection_details) = &metaplex_metadata.collection_details {
+        assert_eq!(
+            additional_meta_map.get("collection_details").unwrap(),
+            &serde_json::to_string(collection_details).unwrap()
+        );
+    }
+    if let Some(creators) = &metaplex_metadata.creators {
+        if !creators.is_empty() {
+            assert_eq!(
+                additional_meta_map.get("creators").unwrap(),
+                &serde_json::to_string(creators).unwrap()
+            );
+        }
+    }
+    if let Some(config) = &metaplex_metadata.programmable_config {
+        assert_eq!(
+            additional_meta_map.get("config").unwrap(),
+            &serde_json::to_string(config).unwrap()
+        );
+    }
+}

--- a/program/tests/helpers/mod.rs
+++ b/program/tests/helpers/mod.rs
@@ -2,6 +2,7 @@ pub mod close_stuck_escrow_builder;
 pub mod common;
 pub mod create_mint_builder;
 pub mod extensions;
+pub mod metadata;
 pub mod mint_builder;
 pub mod sync_metadata_builder;
 pub mod token_account_builder;

--- a/program/tests/programs/mock-metadata-owner/Cargo.toml
+++ b/program/tests/programs/mock-metadata-owner/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "mock-metadata-owner"
+version = "0.1.0"
+edition = { workspace = true }
+publish = false
+
+[features]
+no-entrypoint = []
+
+[dependencies]
+solana-account-info = { workspace = true }
+solana-cpi = { workspace = true }
+solana-program-entrypoint = { workspace = true }
+solana-program-error = { workspace = true }
+solana-pubkey = { workspace = true }
+spl-token-2022 = { workspace = true }
+spl-token-metadata-interface = { workspace = true }
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[lints]
+workspace = true

--- a/program/tests/programs/mock-metadata-owner/src/entrypoint.rs
+++ b/program/tests/programs/mock-metadata-owner/src/entrypoint.rs
@@ -1,0 +1,19 @@
+//! Program entrypoint
+
+#![cfg(all(target_os = "solana", not(feature = "no-entrypoint")))]
+
+use {
+    solana_account_info::AccountInfo, solana_program_error::ProgramResult, solana_pubkey::Pubkey,
+    spl_token_metadata_interface::instruction::TokenMetadataInstruction,
+};
+
+solana_program_entrypoint::entrypoint!(process_instruction);
+
+fn process_instruction(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    instruction_data: &[u8],
+) -> ProgramResult {
+    let ix = TokenMetadataInstruction::unpack(instruction_data)?;
+    crate::processor::process_instruction(program_id, accounts, ix)
+}

--- a/program/tests/programs/mock-metadata-owner/src/lib.rs
+++ b/program/tests/programs/mock-metadata-owner/src/lib.rs
@@ -1,0 +1,7 @@
+use solana_pubkey::Pubkey;
+
+pub mod entrypoint;
+pub mod processor;
+
+pub const ID: Pubkey = Pubkey::new_from_array([3u8; 32]); // success case
+pub const NO_RETURN: Pubkey = Pubkey::new_from_array([4u8; 32]);

--- a/program/tests/programs/mock-metadata-owner/src/processor.rs
+++ b/program/tests/programs/mock-metadata-owner/src/processor.rs
@@ -1,0 +1,47 @@
+//! This mock program simulates a third-party metadata program that chooses to
+//! store its metadata directly within the `TokenMetadata` extension of a
+//! Token-2022 mint account.
+//!
+//! This mock does not implement other instructions like `UpdateField`, as it's
+//! only intended for testing the `Emit` functionality from a caller's
+//! perspective.
+
+use {
+    crate::NO_RETURN,
+    solana_account_info::{next_account_info, AccountInfo},
+    solana_cpi::set_return_data,
+    solana_program_error::ProgramResult,
+    solana_pubkey::Pubkey,
+    spl_token_2022::{
+        extension::{BaseStateWithExtensions, PodStateWithExtensions},
+        pod::PodMint,
+    },
+    spl_token_metadata_interface::{instruction::TokenMetadataInstruction, state::TokenMetadata},
+};
+
+pub fn process_instruction(
+    _program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    ix: TokenMetadataInstruction,
+) -> ProgramResult {
+    let TokenMetadataInstruction::Emit(emit) = ix else {
+        unimplemented!("Instruction not implemented")
+    };
+
+    let account_info_iter = &mut accounts.iter();
+    let metadata_info = next_account_info(account_info_iter)?;
+
+    if *metadata_info.key == NO_RETURN {
+        return Ok(());
+    }
+
+    let data = metadata_info.try_borrow_data()?;
+    let state = PodStateWithExtensions::<PodMint>::unpack(&data)?;
+    let metadata_bytes = state.get_extension_bytes::<TokenMetadata>()?;
+
+    let range = TokenMetadata::get_slice(metadata_bytes, emit.start, emit.end).unwrap();
+
+    set_return_data(range);
+
+    Ok(())
+}

--- a/program/tests/test_pointer_sync.rs
+++ b/program/tests/test_pointer_sync.rs
@@ -1,0 +1,534 @@
+use {
+    crate::helpers::{
+        common::{init_mollusk, KeyedAccount, TokenProgram},
+        extensions::{MintExtension, MintExtension::MetadataPointer},
+        metadata::assert_metaplex_fields_synced,
+        mint_builder::MintBuilder,
+        sync_metadata_builder::SyncMetadataBuilder,
+        token_account_builder::TokenAccountBuilder,
+    },
+    mollusk_svm::{program::create_program_account_loader_v3, result::Check},
+    mpl_token_metadata::{
+        accounts::Metadata as MetaplexMetadata,
+        types::{CollectionDetails, Creator, Key, TokenStandard, UseMethod, Uses},
+    },
+    solana_account::Account,
+    solana_program_error::ProgramError,
+    solana_pubkey::Pubkey,
+    spl_token_2022::{
+        extension::{BaseStateWithExtensions, PodStateWithExtensions, PodStateWithExtensionsMut},
+        pod::PodMint,
+    },
+    spl_token_metadata_interface::state::TokenMetadata,
+    spl_token_wrap::{
+        error::TokenWrapError, get_wrapped_mint_address, get_wrapped_mint_authority, id,
+        instruction::sync_metadata_to_token_2022,
+    },
+};
+
+pub mod helpers;
+
+#[test]
+fn test_pointer_missing_fails() {
+    let unwrapped_mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken2022)
+        .build(); // No metadata extension
+
+    SyncMetadataBuilder::new()
+        .unwrapped_mint(unwrapped_mint)
+        .check(Check::err(TokenWrapError::MetadataPointerMissing.into()))
+        .execute();
+}
+
+#[test]
+fn test_pointer_unset_fails() {
+    let unwrapped_mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken2022)
+        .with_extension(MetadataPointer {
+            metadata_address: None,
+        })
+        .build();
+
+    SyncMetadataBuilder::new()
+        .unwrapped_mint(unwrapped_mint)
+        .check(Check::err(TokenWrapError::MetadataPointerUnset.into()))
+        .execute();
+}
+
+#[test]
+fn test_token_2022_self_pointer_success() {
+    let mint_key = Pubkey::new_unique();
+    let unwrapped_mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken2022)
+        .mint_key(mint_key)
+        .with_extension(MetadataPointer {
+            metadata_address: Some(mint_key),
+        })
+        .with_extension(MintExtension::TokenMetadata {
+            name: "Test Token".to_string(),
+            symbol: "TEST".to_string(),
+            uri: "https://example.com/test.json".to_string(),
+            additional_metadata: vec![],
+        })
+        .build();
+
+    SyncMetadataBuilder::new()
+        .unwrapped_mint(unwrapped_mint)
+        .execute();
+}
+
+#[test]
+fn test_pointer_present_but_no_account_fails() {
+    let external_address = Pubkey::new_unique();
+    let unwrapped_mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken2022)
+        .with_extension(MetadataPointer {
+            metadata_address: Some(external_address),
+        })
+        .build();
+
+    // Don't provide the source_metadata account to the instruction
+    SyncMetadataBuilder::new()
+        .unwrapped_mint(unwrapped_mint)
+        .check(Check::err(ProgramError::NotEnoughAccountKeys))
+        .execute();
+}
+
+#[test]
+fn test_pointer_mismatch_fails() {
+    let pointer_address = Pubkey::new_unique();
+    let unwrapped_mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken2022)
+        .with_extension(MetadataPointer {
+            metadata_address: Some(pointer_address),
+        })
+        .build();
+
+    let wrong_metadata_account = KeyedAccount {
+        key: Pubkey::new_unique(),
+        account: Account::default(),
+    };
+
+    SyncMetadataBuilder::new()
+        .unwrapped_mint(unwrapped_mint)
+        .source_metadata(wrong_metadata_account)
+        .check(Check::err(TokenWrapError::MetadataPointerMismatch.into()))
+        .execute();
+}
+
+#[test]
+fn test_fail_pointer_to_token_2022_account_metadata_unsupported() {
+    let mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken2022)
+        .build();
+    let source_metadata_account = TokenAccountBuilder::new()
+        .token_program(TokenProgram::SplToken2022)
+        .mint(mint)
+        .build();
+
+    let unwrapped_mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken2022)
+        .with_extension(MetadataPointer {
+            metadata_address: Some(source_metadata_account.key),
+        })
+        .build();
+
+    SyncMetadataBuilder::new()
+        .unwrapped_mint(unwrapped_mint)
+        // Source is not allowed to be a token account
+        .source_metadata(source_metadata_account)
+        .check(Check::err(ProgramError::InvalidAccountData))
+        .execute();
+}
+
+#[test]
+fn test_pointing_to_token_2022_success() {
+    let metadata_source_mint_key = Pubkey::new_unique();
+    let unwrapped_mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken2022)
+        .with_extension(MetadataPointer {
+            metadata_address: Some(metadata_source_mint_key),
+        })
+        .build();
+
+    let source_metadata_extension = MintExtension::TokenMetadata {
+        name: "Mock Token".to_string(),
+        symbol: "MOCK".to_string(),
+        uri: "https://example.com/mock.json".to_string(),
+        additional_metadata: vec![("mock_key".to_string(), "mock_value".to_string())],
+    };
+    let mut mock_metadata_account = MintBuilder::new()
+        .token_program(TokenProgram::SplToken2022)
+        .mint_key(metadata_source_mint_key)
+        .with_extension(source_metadata_extension.clone())
+        .build();
+    mock_metadata_account.account.owner = mock_metadata_owner::ID;
+
+    let result = SyncMetadataBuilder::new()
+        .unwrapped_mint(unwrapped_mint)
+        .source_metadata(mock_metadata_account)
+        .execute();
+
+    let wrapped_mint_state =
+        PodStateWithExtensions::<PodMint>::unpack(&result.wrapped_mint.account.data).unwrap();
+    let wrapped_metadata = wrapped_mint_state
+        .get_variable_len_extension::<TokenMetadata>()
+        .unwrap();
+
+    if let MintExtension::TokenMetadata {
+        name,
+        symbol,
+        uri,
+        additional_metadata,
+    } = source_metadata_extension
+    {
+        assert_eq!(wrapped_metadata.name, name);
+        assert_eq!(wrapped_metadata.symbol, symbol);
+        assert_eq!(wrapped_metadata.uri, uri);
+        assert_eq!(wrapped_metadata.additional_metadata, additional_metadata);
+    } else {
+        panic!("Unexpected extension type");
+    }
+}
+
+#[test]
+fn test_pointer_to_metaplex_success() {
+    let unwrapped_mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken2022)
+        .build();
+
+    let metaplex_metadata_obj = MetaplexMetadata {
+        key: Key::MetadataV1,
+        update_authority: Pubkey::new_unique(),
+        mint: unwrapped_mint.key,
+        name: "Metaplex Token".to_string(),
+        symbol: "MPL".to_string(),
+        uri: "https://metaplex.dev/meta.json".to_string(),
+        seller_fee_basis_points: 250,
+        creators: Some(vec![Creator {
+            address: Pubkey::new_unique(),
+            verified: true,
+            share: 100,
+        }]),
+        primary_sale_happened: true,
+        is_mutable: true,
+        edition_nonce: Some(1),
+        token_standard: Some(TokenStandard::NonFungible),
+        collection: Some(mpl_token_metadata::types::Collection {
+            key: Pubkey::new_unique(),
+            verified: false,
+        }),
+        uses: Some(Uses {
+            use_method: UseMethod::Burn,
+            remaining: 0,
+            total: 0,
+        }),
+        collection_details: Some(CollectionDetails::V1 { size: 1 }),
+        programmable_config: None,
+    };
+
+    let (metaplex_pda, _) = MetaplexMetadata::find_pda(&unwrapped_mint.key);
+    let metaplex_account = KeyedAccount {
+        key: metaplex_pda,
+        account: Account {
+            lamports: 1_000_000_000,
+            data: borsh::to_vec(&metaplex_metadata_obj).unwrap(),
+            owner: mpl_token_metadata::ID,
+            executable: false,
+            rent_epoch: 0,
+        },
+    };
+
+    // Point the Token-2022 mint's metadata pointer at the Metaplex PDA
+    let unwrapped_mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken2022)
+        .with_extension(MetadataPointer {
+            metadata_address: Some(metaplex_account.key),
+        })
+        .build();
+
+    let result = SyncMetadataBuilder::new()
+        .unwrapped_mint(unwrapped_mint.clone())
+        .source_metadata(metaplex_account)
+        .execute();
+
+    let mut binding = result.wrapped_mint.account.data.clone();
+    let wrapped_state = PodStateWithExtensionsMut::<PodMint>::unpack(&mut binding).unwrap();
+    let wrapped_tm = wrapped_state
+        .get_variable_len_extension::<TokenMetadata>()
+        .unwrap();
+
+    assert_eq!(wrapped_tm.name, "Metaplex Token");
+    assert_eq!(wrapped_tm.symbol, "MPL");
+    assert_eq!(wrapped_tm.uri, "https://metaplex.dev/meta.json");
+    assert_eq!(
+        Option::<Pubkey>::from(wrapped_tm.update_authority).unwrap(),
+        result.wrapped_mint_authority.key
+    );
+    assert_eq!(wrapped_tm.mint, result.wrapped_mint.key);
+    assert_metaplex_fields_synced(&wrapped_tm, &metaplex_metadata_obj);
+}
+
+#[test]
+fn test_pointer_to_metaplex_with_invalid_data_fails() {
+    let unwrapped_mint_key = Pubkey::new_unique();
+    let (metaplex_pda, _) = MetaplexMetadata::find_pda(&unwrapped_mint_key);
+
+    // Point the unwrapped mint's metadata pointer to the Metaplex PDA
+    let unwrapped_mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken2022)
+        .mint_key(unwrapped_mint_key)
+        .with_extension(MetadataPointer {
+            metadata_address: Some(metaplex_pda),
+        })
+        .build();
+
+    // Create the Metaplex account with invalid data that cannot be deserialized
+    let metaplex_account_invalid_data = KeyedAccount {
+        key: metaplex_pda,
+        account: Account {
+            lamports: 1_000_000_000,
+            data: vec![1, 2, 3], // Invalid data
+            owner: mpl_token_metadata::ID,
+            ..Default::default()
+        },
+    };
+
+    SyncMetadataBuilder::new()
+        .unwrapped_mint(unwrapped_mint)
+        .source_metadata(metaplex_account_invalid_data)
+        .check(Check::err(ProgramError::InvalidAccountData))
+        .execute();
+}
+
+#[test]
+fn test_third_party_missing_owner_program_fails() {
+    let mollusk = init_mollusk();
+
+    let mock_metadata_key = Pubkey::new_unique();
+    let unwrapped_mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken2022)
+        .with_extension(MetadataPointer {
+            metadata_address: Some(mock_metadata_key),
+        })
+        .build();
+
+    let wrapped_mint_address = get_wrapped_mint_address(&unwrapped_mint.key, &spl_token_2022::id());
+    let wrapped_mint_authority = get_wrapped_mint_authority(&wrapped_mint_address);
+    let wrapped_mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken2022)
+        .mint_key(wrapped_mint_address)
+        .with_extension(MetadataPointer {
+            metadata_address: Some(wrapped_mint_address),
+        })
+        .build();
+
+    let mock_metadata_account = KeyedAccount {
+        key: mock_metadata_key,
+        account: Account::default(),
+    };
+
+    let ix = sync_metadata_to_token_2022(
+        &id(),
+        &wrapped_mint.key,
+        &wrapped_mint_authority,
+        &unwrapped_mint.key,
+        Some(&mock_metadata_key),
+        None, // Missing owner program
+    );
+
+    let accounts = &[
+        wrapped_mint.pair(),
+        (wrapped_mint_authority, Account::default()),
+        unwrapped_mint.pair(),
+        TokenProgram::SplToken2022.keyed_account(),
+        mock_metadata_account.pair(),
+    ];
+    mollusk.process_and_validate_instruction(
+        &ix,
+        accounts,
+        &[Check::err(ProgramError::NotEnoughAccountKeys)],
+    );
+}
+
+#[test]
+fn test_pointer_to_third_party_with_wrong_owner_program_fails() {
+    let mollusk = init_mollusk();
+
+    let mock_metadata_key = Pubkey::new_unique();
+    let unwrapped_mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken2022)
+        .with_extension(MetadataPointer {
+            metadata_address: Some(mock_metadata_key),
+        })
+        .build();
+
+    let wrapped_mint_address = get_wrapped_mint_address(&unwrapped_mint.key, &spl_token_2022::id());
+    let wrapped_mint_authority = get_wrapped_mint_authority(&wrapped_mint_address);
+    let wrapped_mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken2022)
+        .mint_key(wrapped_mint_address)
+        .with_extension(MetadataPointer {
+            metadata_address: Some(wrapped_mint_address),
+        })
+        .build();
+
+    // The metadata account is owned by the mock program
+    let mock_metadata_account = KeyedAccount {
+        key: mock_metadata_key,
+        account: Account {
+            owner: mock_metadata_owner::ID,
+            ..Default::default()
+        },
+    };
+
+    // But we provide a *different* program as the owner in the instruction
+    let wrong_owner_program_key = Pubkey::new_unique();
+
+    let ix = sync_metadata_to_token_2022(
+        &id(),
+        &wrapped_mint.key,
+        &wrapped_mint_authority,
+        &unwrapped_mint.key,
+        Some(&mock_metadata_key),
+        Some(&wrong_owner_program_key),
+    );
+
+    let accounts = &[
+        wrapped_mint.pair(),
+        (wrapped_mint_authority, Account::default()),
+        unwrapped_mint.pair(),
+        TokenProgram::SplToken2022.keyed_account(),
+        mock_metadata_account.pair(),
+        (
+            wrong_owner_program_key,
+            create_program_account_loader_v3(&wrong_owner_program_key),
+        ),
+    ];
+
+    mollusk.process_and_validate_instruction(
+        &ix,
+        accounts,
+        &[Check::err(ProgramError::InvalidAccountOwner)],
+    );
+}
+
+#[test]
+fn test_pointer_to_third_party_success() {
+    let mollusk = init_mollusk();
+
+    let source_metadata_extension = MintExtension::TokenMetadata {
+        name: "Mock External Token".to_string(),
+        symbol: "MOCK".to_string(),
+        uri: "https://example.com/mock.json".to_string(),
+        additional_metadata: vec![("external_key".to_string(), "external_value".to_string())],
+    };
+
+    let mock_metadata_key = Pubkey::new_unique();
+
+    let unwrapped_mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken2022)
+        .with_extension(MetadataPointer {
+            metadata_address: Some(mock_metadata_key),
+        })
+        .build();
+
+    let mut mock_metadata_account = MintBuilder::new()
+        .token_program(TokenProgram::SplToken2022)
+        .mint_key(mock_metadata_key)
+        .with_extension(source_metadata_extension.clone())
+        .build();
+    mock_metadata_account.account.owner = mock_metadata_owner::ID;
+
+    let wrapped_mint_address = get_wrapped_mint_address(&unwrapped_mint.key, &spl_token_2022::id());
+    let wrapped_mint_authority = get_wrapped_mint_authority(&wrapped_mint_address);
+    let wrapped_mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken2022)
+        .mint_key(wrapped_mint_address)
+        .with_extension(MetadataPointer {
+            metadata_address: Some(wrapped_mint_address),
+        })
+        .with_extension(MintExtension::TokenMetadata {
+            name: "".to_string(),
+            symbol: "".to_string(),
+            uri: "".to_string(),
+            additional_metadata: vec![],
+        })
+        .build();
+
+    let ix = sync_metadata_to_token_2022(
+        &id(),
+        &wrapped_mint.key,
+        &wrapped_mint_authority,
+        &unwrapped_mint.key,
+        Some(&mock_metadata_key),
+        Some(&mock_metadata_owner::ID),
+    );
+
+    let accounts = &[
+        wrapped_mint.pair(),
+        (wrapped_mint_authority, Account::default()),
+        unwrapped_mint.pair(),
+        TokenProgram::SplToken2022.keyed_account(),
+        mock_metadata_account.pair(),
+        (
+            mock_metadata_owner::ID,
+            create_program_account_loader_v3(&mock_metadata_owner::ID),
+        ),
+    ];
+
+    let result = mollusk.process_and_validate_instruction(&ix, accounts, &[Check::success()]);
+
+    let final_wrapped_mint_account = result.get_account(&wrapped_mint.key).unwrap();
+    let wrapped_mint_state =
+        PodStateWithExtensions::<PodMint>::unpack(&final_wrapped_mint_account.data).unwrap();
+    let wrapped_metadata = wrapped_mint_state
+        .get_variable_len_extension::<TokenMetadata>()
+        .unwrap();
+
+    if let MintExtension::TokenMetadata {
+        name,
+        symbol,
+        uri,
+        additional_metadata,
+    } = source_metadata_extension
+    {
+        assert_eq!(wrapped_metadata.name, name);
+        assert_eq!(wrapped_metadata.symbol, symbol);
+        assert_eq!(wrapped_metadata.uri, uri);
+        assert_eq!(wrapped_metadata.additional_metadata, additional_metadata);
+        assert_eq!(
+            Option::<Pubkey>::from(wrapped_metadata.update_authority).unwrap(),
+            wrapped_mint_authority
+        );
+        assert_eq!(wrapped_metadata.mint, wrapped_mint.key);
+    } else {
+        panic!("Unexpected extension type");
+    }
+}
+
+#[test]
+fn test_pointer_to_third_party_no_return_fails() {
+    let unwrapped_mint = MintBuilder::new()
+        .token_program(TokenProgram::SplToken2022)
+        .with_extension(MetadataPointer {
+            metadata_address: Some(mock_metadata_owner::NO_RETURN),
+        })
+        .build();
+
+    let source_metadata = KeyedAccount {
+        key: mock_metadata_owner::NO_RETURN,
+        account: Account {
+            owner: mock_metadata_owner::ID,
+            ..Default::default()
+        },
+    };
+
+    SyncMetadataBuilder::new()
+        .unwrapped_mint(unwrapped_mint)
+        .source_metadata(source_metadata)
+        .check(Check::err(
+            TokenWrapError::ExternalProgramReturnedNoData.into(),
+        ))
+        .execute();
+}


### PR DESCRIPTION
Follow up from https://github.com/solana-program/token-wrap/pull/229#discussion_r2273783267

`SyncMetadataToToken2022` now follows a Token-2022 mint’s MetadataPointer to load metadata from the following sources:
- Self
- Metaplex PDA
- Another Token-2022 account with TokenMetadata
- Third-party program owner via Emit CPI

In the case of the third-party program, a new test program has been added to exercise that flow.