### PR TITLE
Rust audit fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10689,9 +10689,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "sharded-slab",
  "thread_local",


### PR DESCRIPTION
Resolves `pnpm rust:audit` failing check

- Fixed crate: tracing-subscriber upgraded to 0.3.20
- Advisory resolved: RUSTSEC-2025-0055.