### PR TITLE
Update toolchain to 1.87.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.86.0"
+channel = "1.87.0"


### PR DESCRIPTION
Fixes issue with cargo-semver-checks blocking crate publishing
https://github.com/solana-program/token-wrap/actions/runs/17610978163/job/50032638201