### PR TITLE
Update to remote crate dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9827,39 +9827,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spl-token-wrap"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fedeedf8417f86136fa93df58a62793f11a9c7d692bf413106db06437b0a8d60"
-dependencies = [
- "bytemuck",
- "mpl-token-metadata",
- "num-derive 0.4.2",
- "num-traits",
- "serde_json",
- "solana-account-info",
- "solana-cpi",
- "solana-instruction",
- "solana-msg",
- "solana-program-entrypoint",
- "solana-program-error",
- "solana-program-pack",
- "solana-pubkey",
- "solana-rent",
- "solana-system-interface",
- "solana-sysvar",
- "solana-zk-sdk",
- "spl-associated-token-account-client",
- "spl-pod",
- "spl-token",
- "spl-token-2022 9.0.0",
- "spl-token-metadata-interface",
- "spl-transfer-hook-interface",
- "spl-type-length-value",
- "thiserror 2.0.16",
-]
-
-[[package]]
 name = "spl-token-wrap-cli"
 version = "0.1.0"
 dependencies = [
@@ -9895,7 +9862,7 @@ dependencies = [
  "spl-token",
  "spl-token-2022 9.0.0",
  "spl-token-metadata-interface",
- "spl-token-wrap 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token-wrap",
  "tempfile",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ spl-tlv-account-resolution = "0.10.0"
 spl-token = { version = "8.0.0", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "9.0.0", features = ["no-entrypoint"] }
 spl-token-metadata-interface = "0.7.0"
-spl-token-wrap = { version = "1.0.0", features = ["no-entrypoint"] }
+spl-token-wrap = { version = "1.0.0", path = "program", features = ["no-entrypoint"] }
 spl-transfer-hook-interface = "0.10.0"
 spl-type-length-value = "0.8.0"
 tempfile = "3.22.0"


### PR DESCRIPTION
Now that spl-token-wrap [is published](https://crates.io/crates/spl-token-wrap) to crates.io, the CLI helper crate will need to depend on that prior to being able to publish as well. Otherwise, it will get an error about the local dependency. 