### PR TITLE
Fix types declaration entry path for clients/js

### DIFF
--- a/clients/js/tsconfig.json
+++ b/clients/js/tsconfig.json
@@ -9,8 +9,9 @@
         "incremental": false,
         "declaration": true,
         "declarationDir": "./dist/types",
-        "emitDeclarationOnly": true
+        "emitDeclarationOnly": true,
+        "rootDir": "src"
     },
     "extends": ["@tsconfig/strictest/tsconfig.json"],
-    "include": ["src", "*.ts"]
+    "include": ["src"]
 }


### PR DESCRIPTION
## Problem

`clients/js` (`@solana-program/token-wrap`) ships **no usable type declarations**. `package.json` declares:

```json
"types": "./dist/types/index.d.ts",
"exports": { ".": { "types": "./dist/types/index.d.ts", ... } }
```

…but `pnpm build` actually emits the entry to `./dist/types/**src**/index.d.ts`. The declared path doesn't exist and there is no co-located `.d.ts` next to the JS (declarations use `emitDeclarationOnly` + `declarationDir`), so TypeScript consumers resolve nothing.

`@arethetypeswrong/cli` **before**:

| resolution | result |
|---|---|
| node10 | ❌ No types |
| node16 (from CJS) | ❌ No types |
| node16 (from ESM) | ❌ No types |
| bundler | ❌ No types |

## Cause

`tsconfig.json` had `include: ["src", "*.ts"]`. The `*.ts` glob matches `tsup.config.ts` in the package root, which raises the computed declaration `rootDir` to the package directory — so every emitted declaration gets an extra `src/` path segment (`dist/types/src/index.d.ts`, plus a stray `dist/types/tsup.config.d.ts`).

## Fix

Pin the declaration root to `src` and stop compiling the root-level config file into the declaration output:

```diff
-        "emitDeclarationOnly": true
+        "emitDeclarationOnly": true,
+        "rootDir": "src"
     },
     "extends": ["@tsconfig/strictest/tsconfig.json"],
-    "include": ["src", "*.ts"]
+    "include": ["src"]
```

Now `tsc` emits the entry to the declared `./dist/types/index.d.ts` (and drops the stray `tsup.config.d.ts`). The JS build (`tsup`) is unchanged.

`@arethetypeswrong/cli` **after**:

| resolution | result |
|---|---|
| node10 | 🟢 |
| node16 (from CJS) | 🟢 |
| node16 (from ESM) | 🎭 Masquerading as CJS |
| bundler | 🟢 |

## Note on the remaining `🎭`

The single emitted `dist/types/index.d.ts` is CJS-flavored (the package is `"type": "commonjs"`), so an ESM consumer sees a CJS-shaped declaration for the `.mjs` entry. This is a pre-existing, much milder issue (it was masked by the "No types" failure) and is common to the tsc-single-`.d.ts` build style used across these clients. Fully resolving it needs a dual `.d.ts`/`.d.mts` declaration setup, which is a broader build change; I've kept this PR to the critical fix (consumers now actually get types). Happy to follow up on the dual-declaration setup if desired.

## Verification
`pnpm build` succeeds; `dist/types/index.d.ts` exists with the full public API; `pnpm lint` / `pnpm format:check` unaffected (no source changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)